### PR TITLE
Text: kerning experiment

### DIFF
--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -39,6 +39,7 @@ export default class FontMetric {
 
   install(doc, parentEl) {
     this.element = doc.createElement("div");
+    this.element.name = "fontMetric";
     this.setMeasureNodeStyles(this.element.style, true);
     parentEl.appendChild(this.element);
   }

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -34,6 +34,7 @@ export default class FontMetric {
 
   constructor() {
     this.charMap = [];
+    this.kerningMap = [];
     this.element = null;
   }
 
@@ -89,6 +90,24 @@ export default class FontMetric {
     if (!this.charMap[fontFamily][fontSize][char])
       this.charMap[fontFamily][fontSize][char] = this.measure(fontFamily, fontSize, char);
     return this.charMap[fontFamily][fontSize][char];
+  }
+
+  // FIXME do browsers implement contextual kerning??
+  kerningFor(fontFamily, fontSize, {left, right}) {
+    var charPairStr = `${left}${right}`;
+    if (!this.kerningMap[fontFamily]) {
+      this.kerningMap[fontFamily] = [];
+    }
+    if (!this.kerningMap[fontFamily][fontSize]) {
+      this.kerningMap[fontFamily][fontSize] = [];
+    }
+    if (!this.kerningMap[fontFamily][fontSize][charPairStr]) {
+      let { width: leftWidth }  = this.sizeFor(fontFamily, fontSize, left),
+          { width: rightWidth } = this.sizeFor(fontFamily, fontSize, right),
+          { width: totalWidth } = this.measure(fontFamily, fontSize, charPairStr);
+      this.kerningMap[fontFamily][fontSize][charPairStr] = totalWidth - leftWidth - rightWidth;
+    }
+    return this.kerningMap[fontFamily][fontSize][charPairStr];
   }
 
   sizeForStr(fontFamily, fontSize, str) {

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -92,8 +92,8 @@ export default class FontMetric {
     return this.charMap[fontFamily][fontSize][char];
   }
 
-  // FIXME do browsers implement contextual kerning??
-  kerningFor(fontFamily, fontSize, {left, right}) {
+  // FIXME? do browsers implement contextual kerning?
+  kerningFor(fontFamily, fontSize, left, right) {
     var charPairStr = `${left}${right}`;
     if (!this.kerningMap[fontFamily]) {
       this.kerningMap[fontFamily] = [];

--- a/rendering/renderer.js
+++ b/rendering/renderer.js
@@ -81,20 +81,9 @@ const defaultCSS = `
     }
 }
 
-span.selected {
-  background: #ACCEF7;
-  line-height: normal;
-}
-
-span.cursor {
-  width: 0px;
-  display: inline-block;
-  outline: 1px solid black;
-  line-height: normal;
-}
-
-div.text span {
+div.text-layer span {
   pointer-events: none;
+  line-height: normal;
 }
 
 `;

--- a/tests/text-test.js
+++ b/tests/text-test.js
@@ -28,7 +28,7 @@ function text(string, props) {
 
 var fontMetric = {
   height: 14, width: 6,
-  sizeForStr(fontFamily, fontSize, text) {
+  sizeForStr(fontFamily, fontSize, fontKerning, text) {
     // ea char 10*10
     var lines = string.lines(text),
         maxCols = arr.max(lines, line => line.length).length;
@@ -36,7 +36,8 @@ var fontMetric = {
   },
   sizeFor(fontFamily, fontSize, text) {
     return {width: this.width, height: this.height}
-  }
+  },
+  kerningFor(fontFamily, fontSize, left, right) { return 0 },
 }
 
 

--- a/tests/text-test.js
+++ b/tests/text-test.js
@@ -158,7 +158,7 @@ describe("rendered text", () => {
   afterEach(() => destroyMorphicEnv());
 
   inBrowser("only renders visible part of scrolled text", async () => {
-    var lineHeight = sut.renderer.lines[0].height;
+    var lineHeight = sut.renderer.chunks[0].height;
     Object.assign(sut, {
       clipMode: "auto",
       extent: pt(100,2*lineHeight), position: pt(0,0),

--- a/text/morph.js
+++ b/text/morph.js
@@ -31,7 +31,7 @@ export class Text extends Morph {
       fontFamily: "Sans-Serif",
       fontSize: 12,
       fontColor: Color.black,
-      fontKerning: false,
+      fontKerning: true,
       ...props
     });
     this.document = new TextDocument();

--- a/text/morph.js
+++ b/text/morph.js
@@ -31,7 +31,7 @@ export class Text extends Morph {
       fontFamily: "Sans-Serif",
       fontSize: 12,
       fontColor: Color.black,
-      fontKerning: true,
+      fontKerning: false,
       ...props
     });
     this.document = new TextDocument();

--- a/text/morph.js
+++ b/text/morph.js
@@ -31,6 +31,7 @@ export class Text extends Morph {
       fontFamily: "Sans-Serif",
       fontSize: 12,
       fontColor: Color.black,
+      fontKerning: true,
       ...props
     });
     this.document = new TextDocument();
@@ -50,7 +51,8 @@ export class Text extends Morph {
      || change.prop === "fontSize"
      || change.prop === "fontColor" // FIXME
      || change.prop === "fixedWidth"
-     || change.prop === "fixedHeight")
+     || change.prop === "fixedHeight"
+     || change.prop === "fontKerning")
        this.renderer && (this.renderer.layoutComputed = false);
     super.onChange(change);
   }
@@ -101,6 +103,9 @@ export class Text extends Morph {
 
   get fontColor() { return this.getProperty("fontColor") }
   set fontColor(value) { this.addValueChange("fontColor", value); }
+
+  get fontKerning() { return this.getProperty("fontKerning") }
+  set fontKerning(value) { this.addValueChange("fontKerning", value); }
 
   get clipMode()  { return this.getProperty("clipMode"); }
   set clipMode(value)  {

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -72,8 +72,8 @@ class RenderedChunk {
   }
 
   computeBounds() {
-    let {text, config: {fontFamily, fontSize, fontMetric}} = this,
-        {height, width} = fontMetric.sizeForStr(fontFamily, fontSize, text);
+    let {text, config: {fontFamily, fontSize, fontMetric, fontKerning}} = this,
+        {height, width} = fontMetric.sizeForStr(fontFamily, fontSize, fontKerning, text);
 
     this._height = height;
     this._width = width;

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -81,12 +81,14 @@ class RenderedChunk {
   }
 
   computeCharBounds() {
-    let {text, config: {fontFamily, fontSize, fontMetric}} = this;
+    let {text, config: {fontFamily, fontSize, fontMetric, fontKerning}} = this;
     text += newline;
     let nCols = text.length,
         _charBounds = this._charBounds = new Array(nCols);
     for (let col = 0, x = 0; col < nCols; col++) {
       let {width,height} = fontMetric.sizeFor(fontFamily, fontSize, text[col]);
+      if (fontKerning && col < nCols - 1)
+        width += fontMetric.kerningFor(fontFamily, fontSize, text[col], text[col+1]);
       _charBounds[col] = {x, y: 0, width, height};
       x += width;
     }


### PR DESCRIPTION
The goal of this PR is to make text rendering more accurate by taking into account character kerning. 
#### Example character boundaries without kerning correction:

![screen shot 2016-08-22 at 4 17 02 pm](https://cloud.githubusercontent.com/assets/16568861/17875009/05188bb4-6884-11e6-8663-e6379c5f573a.png)

In this PR, FontMetric computes the kerning for a character pair by comparing the sum of the characters' "stand-alone" widths with the pair's combined width when rendered side-by-side. While apparently not 100% accurate (perhaps due to rounding errors?), these values seem to be reasonable for adjusting character bounds.
#### Corrected character boundaries:

![screen shot 2016-08-22 at 4 19 18 pm](https://cloud.githubusercontent.com/assets/16568861/17875075/6cd5dac2-6884-11e6-8aba-c3fa30462b7e.png)

There's also an option to disable font kerning entirely, using the hacky but cross-browser/cross-font method of wrapping every character in its own `span`.
#### Kerning disabled:

![screen shot 2016-08-22 at 4 19 54 pm](https://cloud.githubusercontent.com/assets/16568861/17875077/70ce6cc0-6884-11e6-8a3c-278af7adffda.png)
