### PR TITLE
Text: more character bounds fixes

### DIFF
--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -34,7 +34,6 @@ export default class FontMetric {
 
   constructor() {
     this.charMap = [];
-    this.kerningMap = [];
     this.element = null;
   }
 
@@ -101,8 +100,7 @@ export default class FontMetric {
   }
 
   sizeFor(fontFamily, fontSize, char) {
-    if (char.length > 1)
-      return this.sizeForStr(fontFamily, fontSize, false, char);
+    if (char.length > 1) return this.measure(fontFamily, fontSize, char);
 
     if (!this.charMap[fontFamily]) {
       this.charMap[fontFamily] = [];
@@ -113,77 +111,6 @@ export default class FontMetric {
     if (!this.charMap[fontFamily][fontSize][char])
       this.charMap[fontFamily][fontSize][char] = this.measure(fontFamily, fontSize, char);
     return this.charMap[fontFamily][fontSize][char];
-  }
-
-  sizeForStr(fontFamily, fontSize, fontKerning, str) {
-    var height = 0, width = 0,
-        defaultLineHeight = this.defaultLineHeight(fontFamily, fontSize);
-    for (let line of str.split('\n')) {
-      let lineHeight = defaultLineHeight, lineWidth = 0,
-          chars = line.split(''), nChars = chars.length;
-      for (let charIndex = 0; charIndex < nChars; charIndex++) {
-        let char = chars[charIndex],
-          { height: charHeight, width: charWidth } = this.sizeFor(fontFamily, fontSize, char);
-        if (charHeight > lineHeight) lineHeight = charHeight;
-        if (fontKerning) {
-          let nextChar = chars[charIndex+1],
-              prevChar = chars[charIndex-1],
-              kerning  = this.kerningFor(fontFamily, fontSize, ...chars.slice(0, charIndex+2)),
-              ligatureOffset = 0;
-          if (charIndex % 2 === 0) {
-            let prevChar = chars[charIndex-1];
-            ligatureOffset = this.ligatureAdjustmentFor(fontFamily, fontSize, prevChar, char, nextChar);
-          }
-          charWidth += kerning + ligatureOffset;
-        }
-        lineWidth += charWidth;
-      }
-      if (lineWidth > width) width = lineWidth;
-      height += lineHeight;
-    }
-    return { height: height, width: width };
-  }
-
-  // FIXME? do browsers implement contextual kerning?
-  kerningFor(fontFamily, fontSize, ...chars) {
-    var left = chars.slice(0, -1).join(''),
-        right = chars.slice(-1).join(''),
-        measureStr = `${left}${right}`,
-        indexStr = `_${measureStr}`;
-    if (measureStr.length < 2 || string.lines(measureStr).length !== 1) return 0;
-    if (!this.kerningMap[fontFamily]) {
-      this.kerningMap[fontFamily] = [];
-    }
-    if (!this.kerningMap[fontFamily][fontSize]) {
-      this.kerningMap[fontFamily][fontSize] = [];
-    }
-    if (this.kerningMap[fontFamily][fontSize][indexStr] === undefined) {
-      let leftWidth = this.measure(fontFamily, fontSize, left).width,
-          rightWidth = this.sizeFor(fontFamily, fontSize, right).width,
-          totalWidth = this.measure(fontFamily, fontSize, measureStr).width;
-      this.kerningMap[fontFamily][fontSize][indexStr] = totalWidth - leftWidth - rightWidth;
-    }
-    return this.kerningMap[fontFamily][fontSize][indexStr];
-  }
-
-  ligatureAdjustmentFor() { return 0 }
-
-  _ligatureAdjustmentFor(fontFamily, fontSize, pre, anchor, next) {
-    var measureStr = `${pre}${anchor}${next}`,
-        indexStr = `_${measureStr}`;
-    if (measureStr.length !== 3 || string.lines(measureStr).length !== 1) return 0;
-    if (!this.kerningMap[fontFamily]) {
-      this.kerningMap[fontFamily] = [];
-    }
-    if (!this.kerningMap[fontFamily][fontSize]) {
-      this.kerningMap[fontFamily][fontSize] = [];
-    }
-    if (this.kerningMap[fontFamily][fontSize][indexStr] === undefined) {
-      let unadjustedWidth = this.sizeForStr(fontFamily, fontSize, true, measureStr).width,
-          measuredWidth = this.measure(fontFamily, fontSize, measureStr).width;
-      this.kerningMap[fontFamily][fontSize][indexStr] = measuredWidth - unadjustedWidth;
-    }
-    return this.kerningMap[fontFamily][fontSize][indexStr];
   }
 
   asciiSizes(fontFamily, fontSize) {

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -81,8 +81,11 @@ export default class FontMetric {
     let nCols = str.length,
         bounds = new Array(nCols);
     for (let col = 0, x = 0; col < nCols; col++) {
-      let width, height;
-      if (fontKerning) {
+      let width, height,
+          w_width = this.sizeFor(fontFamily, fontSize, 'w').width,
+          i_width = this.sizeFor(fontFamily, fontSize, 'i').width,
+          fontIsProportional = (w_width !== i_width);
+      if (fontIsProportional && fontKerning) {
         let prefix = str.substr(0, col+1),
             { width: prefixWidth, height: prefixHeight } = this.measure(fontFamily, fontSize, prefix);
         width = prefixWidth - x;

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -77,6 +77,26 @@ export default class FontMetric {
     }
   }
 
+  charBoundsForStr(fontFamily, fontSize, fontKerning, str) {
+    let nCols = str.length,
+        bounds = new Array(nCols);
+    for (let col = 0, x = 0; col < nCols; col++) {
+      let width, height;
+      if (fontKerning) {
+        let prefix = str.substr(0, col+1),
+            { width: prefixWidth, height: prefixHeight } = this.measure(fontFamily, fontSize, prefix);
+        width = prefixWidth - x;
+        height = prefixHeight;
+      } else {
+        let char = str[col];
+        ({ width, height } = this.sizeFor(fontFamily, fontSize, char));
+      }
+      bounds[col] = { x, y: 0, width, height };
+      x += width;
+    }
+    return bounds;
+  }
+
   sizeFor(fontFamily, fontSize, char) {
     if (char.length > 1)
       return this.sizeForStr(fontFamily, fontSize, false, char);

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -104,7 +104,8 @@ export default class FontMetric {
         if (charHeight > lineHeight) lineHeight = charHeight;
         if (fontKerning) {
           let nextChar = chars[charIndex+1],
-              kerning  = this.kerningFor(fontFamily, fontSize, char, nextChar),
+              prevChar = chars[charIndex-1],
+              kerning  = this.kerningFor(fontFamily, fontSize, ...chars.slice(0, charIndex+2)),
               ligatureOffset = 0;
           if (charIndex % 2 === 0) {
             let prevChar = chars[charIndex-1];
@@ -121,10 +122,12 @@ export default class FontMetric {
   }
 
   // FIXME? do browsers implement contextual kerning?
-  kerningFor(fontFamily, fontSize, left, right) {
-    var measureStr = `${left}${right}`,
+  kerningFor(fontFamily, fontSize, ...chars) {
+    var left = chars.slice(0, -1).join(''),
+        right = chars.slice(-1).join(''),
+        measureStr = `${left}${right}`,
         indexStr = `_${measureStr}`;
-    if (measureStr.length !== 2 || string.lines(measureStr).length !== 1) return 0;
+    if (measureStr.length < 2 || string.lines(measureStr).length !== 1) return 0;
     if (!this.kerningMap[fontFamily]) {
       this.kerningMap[fontFamily] = [];
     }
@@ -132,7 +135,7 @@ export default class FontMetric {
       this.kerningMap[fontFamily][fontSize] = [];
     }
     if (this.kerningMap[fontFamily][fontSize][indexStr] === undefined) {
-      let leftWidth = this.sizeFor(fontFamily, fontSize, left).width,
+      let leftWidth = this.measure(fontFamily, fontSize, left).width,
           rightWidth = this.sizeFor(fontFamily, fontSize, right).width,
           totalWidth = this.measure(fontFamily, fontSize, measureStr).width;
       this.kerningMap[fontFamily][fontSize][indexStr] = totalWidth - leftWidth - rightWidth;
@@ -140,7 +143,9 @@ export default class FontMetric {
     return this.kerningMap[fontFamily][fontSize][indexStr];
   }
 
-  ligatureAdjustmentFor(fontFamily, fontSize, pre, anchor, next) {
+  ligatureAdjustmentFor() { return 0 }
+
+  _ligatureAdjustmentFor(fontFamily, fontSize, pre, anchor, next) {
     var measureStr = `${pre}${anchor}${next}`,
         indexStr = `_${measureStr}`;
     if (measureStr.length !== 3 || string.lines(measureStr).length !== 1) return 0;

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -2,12 +2,6 @@ import { arr, string } from "lively.lang"
 
 export var dummyFontMetric = {
   height: 14, width: 6,
-  sizeForStr(fontFamily, fontSize, fontKerning, text) {
-    // ea char 10*10
-    var lines = string.lines(text),
-        maxCols = arr.max(lines, line => line.length).length;
-    return {width: maxCols*this.width, height: lines.length*this.height}
-  },
   sizeFor(fontFamily, fontSize, text) {
     return {width: this.width, height: this.height}
   },

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -11,5 +11,6 @@ export var dummyFontMetric = {
   sizeFor(fontFamily, fontSize, text) {
     return {width: this.width, height: this.height}
   },
-  kerningFor(fontFamily, fontSize, left, right) { return 0 },
+  kerningFor: () => 0,
+  ligatureAdjustmentFor: () => 0
 }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -11,6 +11,16 @@ export var dummyFontMetric = {
   sizeFor(fontFamily, fontSize, text) {
     return {width: this.width, height: this.height}
   },
+  charBoundsForStr(fontFamily, fontSize, fontKerning, text) {
+    var prevX = 0;
+    return text.split('').map(function (char, col) {
+      let x = prevX,
+          { width, height } = this;
+      if (col === text.length - 1) width = 0;
+      prevX += width;
+      return { x, y: 0, width, height };
+    }, this);
+  },
   kerningFor: () => 0,
   ligatureAdjustmentFor: () => 0
 }

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -5,7 +5,7 @@ export var dummyFontMetric = {
   sizeFor(fontFamily, fontSize, text) {
     return {width: this.width, height: this.height}
   },
-  charBoundsForStr(fontFamily, fontSize, fontKerning, text) {
+  charBoundsFor(fontFamily, fontSize, fontKerning, text) {
     var prevX = 0;
     return text.split('').map(function (char, col) {
       let x = prevX,

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -97,7 +97,6 @@ class RenderedChunk {
           let prevChar = text[col-1];
           ligatureOffset = fontMetric.ligatureAdjustmentFor(fontFamily, fontSize, prevChar, char, nextChar);
         }
-        console.log(`${kerning}/${ligatureOffset}`)
         width += kerning + ligatureOffset;
       }
       _charBounds[col] = {x, y: 0, width, height};

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -85,8 +85,8 @@ class RenderedChunk {
 
   computeCharBounds() {
     let { _charBounds, text, config: { fontFamily, fontSize, fontMetric, fontKerning } } = this;
-    text += "\u200b";
-    this._charBounds = fontMetric.charBoundsForStr(fontFamily, fontSize, fontKerning, text);
+    text += newline;
+    this._charBounds = fontMetric.charBoundsFor(fontFamily, fontSize, fontKerning, text);
   }
 
   render() {

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -73,36 +73,20 @@ class RenderedChunk {
   }
 
   computeBounds() {
-    let {text, config: {fontFamily, fontSize, fontMetric, fontKerning}} = this,
-        {height, width} = fontMetric.sizeForStr(fontFamily, fontSize, fontKerning, text);
-
+    let width = 0, height = 0;
+    this.charBounds.map(char => {
+      width += char.width;
+      height = Math.max(height, char.height);
+    });
     this._height = height;
     this._width = width;
     return this;
   }
 
   computeCharBounds() {
-    let {text, config: {fontFamily, fontSize, fontMetric, fontKerning}} = this;
-    text += newline;
-    let nCols = text.length,
-        _charBounds = this._charBounds = new Array(nCols);
-    for (let col = 0, x = 0; col < nCols; col++) {
-      let char = text[col],
-          {width,height} = fontMetric.sizeFor(fontFamily, fontSize, char);
-      if (fontKerning) { // last column is newline
-        let nextChar = text[col+1],
-          prevChar = text[col-1],
-            kerning = fontMetric.kerningFor(fontFamily, fontSize, ...text.slice(0, col+2)),
-            ligatureOffset = 0;
-        if (col % 2 === 0) {
-          let prevChar = text[col-1];
-          ligatureOffset = fontMetric.ligatureAdjustmentFor(fontFamily, fontSize, prevChar, char, nextChar);
-        }
-        width += kerning + ligatureOffset;
-      }
-      _charBounds[col] = {x, y: 0, width, height};
-      x += width;
-    }
+    let { _charBounds, text, config: { fontFamily, fontSize, fontMetric, fontKerning } } = this;
+    text += "\u200b";
+    this._charBounds = fontMetric.charBoundsForStr(fontFamily, fontSize, fontKerning, text);
   }
 
   render() {

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -87,9 +87,19 @@ class RenderedChunk {
     let nCols = text.length,
         _charBounds = this._charBounds = new Array(nCols);
     for (let col = 0, x = 0; col < nCols; col++) {
-      let {width,height} = fontMetric.sizeFor(fontFamily, fontSize, text[col]);
-      if (fontKerning && col < nCols - 2) // last column is newline
-        width += fontMetric.kerningFor(fontFamily, fontSize, text[col], text[col+1]);
+      let char = text[col],
+          {width,height} = fontMetric.sizeFor(fontFamily, fontSize, char);
+      if (fontKerning) { // last column is newline
+        let nextChar = text[col+1],
+            kerning = fontMetric.kerningFor(fontFamily, fontSize, char, nextChar),
+            ligatureOffset = 0;
+        if (col % 2 === 0) {
+          let prevChar = text[col-1];
+          ligatureOffset = fontMetric.ligatureAdjustmentFor(fontFamily, fontSize, prevChar, char, nextChar);
+        }
+        console.log(`${kerning}/${ligatureOffset}`)
+        width += kerning + ligatureOffset;
+      }
       _charBounds[col] = {x, y: 0, width, height};
       x += width;
     }

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -45,14 +45,14 @@ class RenderedChunk {
     return this;
   }
 
-  compatibleWith(text2, fontFamily2, fontSize2, fontMetric2, fontColor2, fontKerning2) {
-    var {text, config: {fontFamily, fontSize, fontMetric, fontColor, fontKerning}} = this;
-    return text       === text2
-        && fontFamily === fontFamily2
-        && fontSize   === fontSize2
-        && fontColor  === fontColor2
-        && fontMetric === fontMetric2
-        && fontKerning === fontKerning2;
+  compatibleWith(text2, config2) {
+    var {text, config} = this;
+    return text               === text2
+        && config.fontFamily  === config2.fontFamily
+        && config.fontSize    === config2.fontSize
+        && config.fontColor   === config2.fontColor
+        && config.fontMetric  === config2.fontMetric
+        && config.fontKerning === config2.fontKerning;
   }
 
   get height() {
@@ -157,9 +157,11 @@ export default class TextLayout {
 
     // for now: 1 line = 1 chunk
     for (let row = 0; row < nRows; row++) {
-      var chunk = this.chunks[row];
-      if (!chunk || !chunk.compatibleWith(lines[row], fontFamily, fontSize, fontColor, fontKerning, fontMetric))
-        this.chunks[row] = new RenderedChunk(lines[row], {fontFamily, fontSize, fontColor, fontKerning, fontMetric});
+      var chunk = this.chunks[row],
+          text = lines[row],
+          config = { fontMetric, fontFamily, fontSize, fontColor, fontKerning };
+      if (!chunk || !chunk.compatibleWith(text, config))
+        this.chunks[row] = new RenderedChunk(text, config);
     }
 
     this.chunks.splice(nRows, this.chunks.length - nRows);

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -91,7 +91,8 @@ class RenderedChunk {
           {width,height} = fontMetric.sizeFor(fontFamily, fontSize, char);
       if (fontKerning) { // last column is newline
         let nextChar = text[col+1],
-            kerning = fontMetric.kerningFor(fontFamily, fontSize, char, nextChar),
+          prevChar = text[col-1],
+            kerning = fontMetric.kerningFor(fontFamily, fontSize, ...text.slice(0, col+2)),
             ligatureOffset = 0;
         if (col % 2 === 0) {
           let prevChar = text[col-1];

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -84,7 +84,7 @@ class RenderedChunk {
   }
 
   computeCharBounds() {
-    let { _charBounds, text, config: { fontFamily, fontSize, fontMetric, fontKerning } } = this;
+    let {text, config: {fontFamily, fontSize, fontMetric, fontKerning}} = this;
     text += newline;
     this._charBounds = fontMetric.charBoundsFor(fontFamily, fontSize, fontKerning, text);
   }


### PR DESCRIPTION
While #24 helped with some of the most common character spacing issues, there were lingering problems with e.g. ligatures.

Example Helvetica string containing ligatures, with skewed bounds:
<img width="132" alt="screenshot - original" src="https://cloud.githubusercontent.com/assets/16568861/18025533/1cf316c2-6be1-11e6-9875-10129365638e.png">

In this PR, character bounds are determined by comparing the widths of substrings; to compute bounds for "lively", for example, `FontMetric.charBoundsFor()` would compute the size of "l", "li", "liv", "live", and so on, to get the bounds of each character. While slower than the previous method, `charBoundsFor` includes caching to speed up the common case of extending an existing line, e.g. when the user types text at the end of a line.

Corrected bounds:
<img width="134" alt="screenshot - corrected" src="https://cloud.githubusercontent.com/assets/16568861/18025537/40a21866-6be1-11e6-9139-eab2295b39bf.png">
