### PR TITLE
Syntax highlighting improvement

### DIFF
--- a/ide/code-editor.js
+++ b/ide/code-editor.js
@@ -68,7 +68,7 @@ export default class CodeEditor extends Morph {
           tokens = this.mode.highlight(txt.textString),
           defaultStyle = this.submorphs[0].styleProps,
           styleRanges = tokens.map(({token, from, to}) =>
-            StyleRange.fromPositions({...defaultStyle, ...this.theme.style(token)}, from, to));
+            StyleRange.fromPositions({...defaultStyle, ...this.theme.styleCached(token)}, from, to));
     styleRanges.push(StyleRange.create(defaultStyle, 0, -1, 0, 0));
     txt.replaceStyleRanges(styleRanges);
 

--- a/ide/highlighting.js
+++ b/ide/highlighting.js
@@ -66,6 +66,8 @@ export class Highlighter {
 
 export class Theme {
   
+  constructor() { this._cache = {}; }
+  
   background() { // -> Color
     throw new Error("not implemented");
   }
@@ -73,6 +75,10 @@ export class Theme {
   style(token) { // Token -> Style
     // return style for token
     throw new Error("not implemented");
+  }
+  
+  styleCached(token) {
+    return this._cache[token] || (this._cache[token] = this.style(token));
   }
   
 }

--- a/ide/highlighting.js
+++ b/ide/highlighting.js
@@ -7,7 +7,9 @@ export const Token = {
   string: "string",
   comment: "comment",
   default: "default",
-  dynamic: "dynamic"
+  dynamic: "dynamic",
+  regex: "regex",
+  error: "error"
 };
 
 

--- a/ide/modes/javascript-highlighter.js
+++ b/ide/modes/javascript-highlighter.js
@@ -196,10 +196,9 @@ export default class JavaScriptHighlighter extends Highlighter {
 /*
 Profiling code:
 
-import JavaScriptMode from "lively.morphic/ide/modes/javascript.js";
+import JavaScriptMode from "lively.morphic/ide/modes/javascript-highlighter.js";
 const mode = new JavaScriptMode(),
-     src = await System.resource("lively.morphic/menus.js").read();
-mode.reset();
+     src = await System.resource("https://dev.lively-web.org/node_modules/lively.morphic/morph.js").read();
 const start = Date.now();
 mode.highlight(src);
 const timeMS = Date.now() - start;

--- a/ide/themes/chrome.js
+++ b/ide/themes/chrome.js
@@ -16,6 +16,8 @@ export default class ChromeTheme extends Theme {
       case Token.numeric: return { fontColor: Color.rgb(0, 0, 205), fontWeight: "bold" };
       case Token.string: return { fontColor: Color.rgbHex("#1a1aa6"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#236e24"), fontWeight: "bold" };
+      case Token.regex: return { fontColor: Color.rgbHex("#1a1aa6"), fontWeight: "bold" };
+      case Token.error: return { backgroundColor: Color.rgbHex("#ff4c4c"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#333"), fontWeight: "bold" };
     }
   }

--- a/ide/themes/github.js
+++ b/ide/themes/github.js
@@ -16,6 +16,8 @@ export default class GithubTheme extends Theme {
       case Token.numeric: return { fontColor: Color.rgbHex("#0086b3"), fontWeight: "bold" };
       case Token.string: return { fontColor: Color.rgbHex("#183691"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#969896"), fontWeight: "bold" };
+      case Token.regex: return { fontColor: Color.rgbHex("#009926"), fontWeight: "bold" };
+      case Token.error: return { backgroundColor: Color.rgbHex("#ff4c4c"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#333"), fontWeight: "bold" };
     }
   }

--- a/ide/themes/tomorrow-night.js
+++ b/ide/themes/tomorrow-night.js
@@ -16,6 +16,8 @@ export default class TomorrowNightTheme extends Theme {
       case Token.numeric: return { fontColor: Color.rgbHex("#e78c45"), fontWeight: "bold" };
       case Token.string: return { fontColor: Color.rgbHex("#b9ca4a"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#969896"), fontWeight: "bold" };
+      case Token.regex: return { fontColor: Color.rgbHex("#d54e53"), fontWeight: "bold" };
+      case Token.error: return { backgroundColor: Color.rgbHex("#641d1d"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#dedede"), fontWeight: "bold" };
     }
   }

--- a/tests/ide/highlighting.js
+++ b/tests/ide/highlighting.js
@@ -1,0 +1,185 @@
+/*global describe, beforeEach, it*/
+import { expect } from "mocha-es6";
+
+import { Token } from "../../ide/highlighting.js";
+import JavaScriptHighlighting from "../../ide/modes/javascript-highlighter.js";
+
+describe("javascript highlighting", () => {
+  
+  let mode;
+  beforeEach(() => {
+    mode = new JavaScriptHighlighting();
+  });
+
+  it("matches numerics", () => {
+    const src = `23 + 12`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.numeric, from: {row: 0, column: 0}, to: {row: 0, column: 2}},
+      {token: Token.default, from: {row: 0, column: 2}, to: {row: 0, column: 5}},
+      {token: Token.numeric, from: {row: 0, column: 5}, to: {row: 0, column: 7}}
+    ]);
+  });
+  
+  it("matches identifiers", () => {
+    const src = `x.y`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.id, from: {row: 0, column: 0}, to: {row: 0, column: 1}},
+      {token: Token.default, from: {row: 0, column: 1}, to: {row: 0, column: 2}},
+      {token: Token.id, from: {row: 0, column: 2}, to: {row: 0, column: 3}}
+    ]);
+  });
+  
+  it("matches single-quoted strings", () => {
+    const src = `'"' + '\\''`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 0, column: 3}},
+      {token: Token.default, from: {row: 0, column: 3}, to: {row: 0, column: 6}},
+      {token: Token.string, from: {row: 0, column: 6}, to: {row: 0, column: 10}}
+    ]);
+  });
+  
+  it("matches double-quoted strings", () => {
+    const src = `"'" + "\\""`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 0, column: 3}},
+      {token: Token.default, from: {row: 0, column: 3}, to: {row: 0, column: 6}},
+      {token: Token.string, from: {row: 0, column: 6}, to: {row: 0, column: 10}}
+    ]);
+  });
+  
+  it("limits strings to single lines", () => {
+    const src = `"t\nr"`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 0, column: 2}},
+      {token: Token.error, from: {row: 0, column: 2}, to: {row: 1, column: 0}},
+      {token: Token.id, from: {row: 1, column: 0}, to: {row: 1, column: 1}},
+      {token: Token.string, from: {row: 1, column: 1}, to: {row: 1, column: 2}}
+    ]);
+  });
+  
+  it("limits strings to single lines unless escaped", () => {
+    const src = `"t\\\nr"`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 1, column: 2}}
+    ]);
+  });
+  
+  it("matches simple templates", () => {
+    const src = '`x` + `\\``';
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 0, column: 3}},
+      {token: Token.default, from: {row: 0, column: 3}, to: {row: 0, column: 6}},
+      {token: Token.string, from: {row: 0, column: 6}, to: {row: 0, column: 10}}
+    ]);
+  });
+  
+  it("matches multi-line templates", () => {
+    const src = '`x\ny`';
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.string, from: {row: 0, column: 0}, to: {row: 1, column: 2}}
+    ]);
+  });
+  
+  it("matches templates with interpolation", () => {
+    const src = 'let x = 23; `${{x231:x}[`x${x+`${2-1}`}`]}`';
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.keyword, from: {row: 0, column: 0}, to: {row: 0, column: 3}},
+      {token: Token.default, from: {row: 0, column: 3}, to: {row: 0, column: 4}},
+      {token: Token.id, from: {row: 0, column: 4}, to: {row: 0, column: 5}},
+      {token: Token.default, from: {row: 0, column: 5}, to: {row: 0, column: 8}},
+      {token: Token.numeric, from: {row: 0, column: 8}, to: {row: 0, column: 10}},
+      {token: Token.default, from: {row: 0, column: 10}, to: {row: 0, column: 12}},
+      {token: Token.string, from: {row: 0, column: 12}, to: {row: 0, column: 13}},
+      {token: Token.default, from: {row: 0, column: 13}, to: {row: 0, column: 16}},
+      {token: Token.id, from: {row: 0, column: 16}, to: {row: 0, column: 20}},
+      {token: Token.default, from: {row: 0, column: 20}, to: {row: 0, column: 21}},
+      {token: Token.id, from: {row: 0, column: 21}, to: {row: 0, column: 22}},
+      {token: Token.default, from: {row: 0, column: 22}, to: {row: 0, column: 24}},
+      {token: Token.string, from: {row: 0, column: 24}, to: {row: 0, column: 26}},
+      {token: Token.default, from: {row: 0, column: 26}, to: {row: 0, column: 28}},
+      {token: Token.id, from: {row: 0, column: 28}, to: {row: 0, column: 29}},
+      {token: Token.default, from: {row: 0, column: 29}, to: {row: 0, column: 30}},
+      {token: Token.string, from: {row: 0, column: 30}, to: {row: 0, column: 31}},
+      {token: Token.default, from: {row: 0, column: 31}, to: {row: 0, column: 33}},
+      {token: Token.numeric, from: {row: 0, column: 33}, to: {row: 0, column: 34}},
+      {token: Token.default, from: {row: 0, column: 34}, to: {row: 0, column: 35}},
+      {token: Token.numeric, from: {row: 0, column: 35}, to: {row: 0, column: 36}},
+      {token: Token.default, from: {row: 0, column: 36}, to: {row: 0, column: 37}},
+      {token: Token.string, from: {row: 0, column: 37}, to: {row: 0, column: 38}},
+      {token: Token.default, from: {row: 0, column: 38}, to: {row: 0, column: 39}},
+      {token: Token.string, from: {row: 0, column: 39}, to: {row: 0, column: 40}},
+      {token: Token.default, from: {row: 0, column: 40}, to: {row: 0, column: 42}},
+      {token: Token.string, from: {row: 0, column: 42}, to: {row: 0, column: 43}}
+    ]);
+  });
+  
+  it("matches comments", () => {
+    const src = "this.renderer/*not init'ed yet*/) return";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.dynamic, from: {row: 0, column: 0}, to: {row: 0, column: 4}},
+      {token: Token.default, from: {row: 0, column: 4}, to: {row: 0, column: 5}},
+      {token: Token.id, from: {row: 0, column: 5}, to: {row: 0, column: 13}},
+      {token: Token.comment, from: {row: 0, column: 13}, to: {row: 0, column: 32}},
+      {token: Token.default, from: {row: 0, column: 32}, to: {row: 0, column: 34}},
+      {token: Token.keyword, from: {row: 0, column: 34}, to: {row: 0, column: 40}}
+    ]);
+  });
+  
+  it("matches line comments", () => {
+    const src = "this// comment\nends";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.dynamic, from: {row: 0, column: 0}, to: {row: 0, column: 4}},
+      {token: Token.comment, from: {row: 0, column: 4}, to: {row: 1, column: 0}},
+      {token: Token.id, from: {row: 1, column: 0}, to: {row: 1, column: 4}}
+    ]);
+  });
+  
+  it("matches keywords", () => {
+    const src = "return 1";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.keyword, from: {row: 0, column: 0}, to: {row: 0, column: 6}},
+      {token: Token.default, from: {row: 0, column: 6}, to: {row: 0, column: 7}},
+      {token: Token.numeric, from: {row: 0, column: 7}, to: {row: 0, column: 8}}
+    ]);
+  });
+  
+  it("matches constants", () => {
+    const src = "!true";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.default, from: {row: 0, column: 0}, to: {row: 0, column: 1}},
+      {token: Token.constant, from: {row: 0, column: 1}, to: {row: 0, column: 5}}
+    ]);
+  });
+  
+  it("matches globals", () => {
+    const src = "Math.max()";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.global, from: {row: 0, column: 0}, to: {row: 0, column: 4}},
+      {token: Token.default, from: {row: 0, column: 4}, to: {row: 0, column: 5}},
+      {token: Token.id, from: {row: 0, column: 5}, to: {row: 0, column: 8}},
+      {token: Token.default, from: {row: 0, column: 8}, to: {row: 0, column: 10}}
+    ]);
+  });
+
+  it("matches dynamic", () => {
+    const src = "this.x";
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.dynamic, from: {row: 0, column: 0}, to: {row: 0, column: 4}},
+      {token: Token.default, from: {row: 0, column: 4}, to: {row: 0, column: 5}},
+      {token: Token.id, from: {row: 0, column: 5}, to: {row: 0, column: 6}}
+    ]);
+  });
+  
+  it("matches simple regular expressions", () => {
+    const src = `/x|y/g.test("x")`;
+    expect(mode.highlight(src)).to.be.deep.equal([
+      {token: Token.regex, from: {row: 0, column: 0}, to: {row: 0, column: 6}},
+      {token: Token.default, from: {row: 0, column: 6}, to: {row: 0, column: 7}},
+      {token: Token.id, from: {row: 0, column: 7}, to: {row: 0, column: 11}},
+      {token: Token.default, from: {row: 0, column: 11}, to: {row: 0, column: 12}},
+      {token: Token.string, from: {row: 0, column: 12}, to: {row: 0, column: 15}},
+      {token: Token.default, from: {row: 0, column: 15}, to: {row: 0, column: 16}}
+    ]);
+  });
+  
+});

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -245,12 +245,13 @@ class RenderedChunk {
   render() {
     if (this.rendered) return this.rendered;
     var {config:
-          {style: {fontSize, fontFamily, fontColor,
+          {style: {fontSize, fontFamily, fontColor, backgroundColor,
                    fontWeight, fontStyle, textDecoration,
                    fixedCharacterSpacing}},
           text, width, height} = this,
         textNodes = text ?
           (fixedCharacterSpacing ? text.split("").map(c => h("span", c)) : text) : h("br");
+    backgroundColor = backgroundColor || "",
     fontColor = fontColor || "";
 
     return this.rendered = h("span", {
@@ -260,7 +261,8 @@ class RenderedChunk {
         fontWeight,
         fontStyle,
         textDecoration,
-        color: String(fontColor)
+        color: String(fontColor),
+        backgroundColor: String(backgroundColor)
       }
     }, textNodes);
   }


### PR DESCRIPTION
- changed handling of templates to support infinite nesting of interpolated templates
- fixed comment bug (#68)
- added basic support for regular expressions (will match any regular expression as long as it doesn't include spaces or escaped forward slashes). might detect a division operation as regular expression (see #62) and does not check for redundant regex flags (e.g. `/foo/gii`)
- themes reuse style objects to improve performance
- single and double-quoted strings are always terminated at the end of the line (unless escaped)
- superfluous closing curly braces will be highlighted as error
- added test suite with 16 tests for various JavaScript syntax chunks
