### PR TITLE
Version control tool

### DIFF
--- a/ide/code-editor.js
+++ b/ide/code-editor.js
@@ -10,14 +10,16 @@ import { Token, Highlighter, Theme } from "./highlighting.js";
 import JavaScriptHighlighter from "./modes/javascript-highlighter.js";
 import JavaScriptChecker from "./modes/javascript-checker.js";
 import PlainHighlighter from "./modes/plain.js";
+import DiffHighlighter from "./modes/diff.js";
 import ChromeTheme from "./themes/chrome.js";
 import TomorrowNightTheme from "./themes/tomorrow-night.js";
 import GithubTheme from "./themes/github.js";
 
 const highlighters = {
   "plain": PlainHighlighter,
-  "javascript": JavaScriptHighlighter
-}
+  "javascript": JavaScriptHighlighter,
+  "diff": DiffHighlighter
+};
 
 const checkers = {
   "plain": null,

--- a/ide/highlighting.js
+++ b/ide/highlighting.js
@@ -9,6 +9,7 @@ export const Token = {
   default: "default",
   dynamic: "dynamic",
   regex: "regex",
+  context: "context",
   error: "error"
 };
 

--- a/ide/modes/diff.js
+++ b/ide/modes/diff.js
@@ -1,0 +1,43 @@
+import { Token, Highlighter } from "../highlighting.js";
+
+export default class DiffHighlighter extends Highlighter {
+  reset() {
+    this.state = "start";
+  }
+  process() { // -> Token
+    const c = this.next();
+    switch (this.state) {
+      case "start":
+        if (c === "+") {
+          this.state = "added";
+          return Token.default;
+        }
+        if (c === "-") {
+          this.state = "removed";
+          return Token.string;
+        }
+        this.state = "unchanged";
+        return Token.context;
+
+      case "added":
+        if (c === '\n') {
+          this.state = "start";
+        }
+        return Token.default;
+
+      case "removed":
+        if (c === '\n') {
+          this.state = "start";
+        }
+        return Token.string;
+        
+      case "unchanged":
+        if (c === '\n') {
+          this.state = "start";
+        }
+        return Token.context;
+
+    }
+    return Token.default;
+  }
+}

--- a/ide/themes/chrome.js
+++ b/ide/themes/chrome.js
@@ -17,6 +17,7 @@ export default class ChromeTheme extends Theme {
       case Token.string: return { fontColor: Color.rgbHex("#1a1aa6"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#236e24"), fontWeight: "bold" };
       case Token.regex: return { fontColor: Color.rgbHex("#1a1aa6"), fontWeight: "bold" };
+      case Token.context: return { fontColor: Color.rgb(191, 191, 191), fontWeight: "bold" };
       case Token.error: return { backgroundColor: Color.rgbHex("#ff4c4c"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#333"), fontWeight: "bold" };
     }

--- a/ide/themes/github.js
+++ b/ide/themes/github.js
@@ -17,6 +17,7 @@ export default class GithubTheme extends Theme {
       case Token.string: return { fontColor: Color.rgbHex("#183691"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#969896"), fontWeight: "bold" };
       case Token.regex: return { fontColor: Color.rgbHex("#009926"), fontWeight: "bold" };
+      case Token.context: return { fontColor: Color.rgbHex("#bfbfbf"), fontWeight: "bold" };
       case Token.error: return { backgroundColor: Color.rgbHex("#ff4c4c"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#333"), fontWeight: "bold" };
     }

--- a/ide/themes/tomorrow-night.js
+++ b/ide/themes/tomorrow-night.js
@@ -4,7 +4,7 @@ import { Token, Theme } from "../highlighting.js";
 
 export default class TomorrowNightTheme extends Theme {
   background() { // -> Color
-    return Color.rgbHex("#1a1a1a");
+    return Color.rgbHex("#0a0a0a");
   }
   style(token) { // Token -> Style
     switch (token) {
@@ -17,6 +17,7 @@ export default class TomorrowNightTheme extends Theme {
       case Token.string: return { fontColor: Color.rgbHex("#b9ca4a"), fontWeight: "bold" };
       case Token.comment: return { fontColor: Color.rgbHex("#969896"), fontWeight: "bold" };
       case Token.regex: return { fontColor: Color.rgbHex("#d54e53"), fontWeight: "bold" };
+      case Token.context: return { fontColor: Color.rgbHex("#454545"), fontWeight: "bold" };
       case Token.error: return { backgroundColor: Color.rgbHex("#641d1d"), fontWeight: "bold" };
       default: return { fontColor: Color.rgbHex("#dedede"), fontWeight: "bold" };
     }

--- a/ide/version-control.js
+++ b/ide/version-control.js
@@ -1,0 +1,597 @@
+import { arr, obj } from "lively.lang";
+import { connect, disconnect, signal } from "lively.bindings";
+import { Color, pt } from "lively.graphics";
+import { localInterface } from "lively-system-interface";
+import { commit, branch, localBranchesOf, gitHubBranches } from "lively.changesets";
+import { activeCommit } from "lively.changesets/src/commit.js";
+import { getAuthor, setAuthor, getGitHubToken, setGitHubToken } from "lively.changesets/src/settings.js";
+import { subscribe, unsubscribe } from "lively.notifications";
+
+import { morph, Morph } from "../index.js";
+import { Window } from "../widgets.js";
+import { StyleRange } from "../text/style.js";
+import CodeEditor from "./code-editor.js";
+import { GridLayout, HorizontalLayout } from "../layout.js";
+
+function pad(m) { // Morph -> Morph
+  return {
+    name: m.name + "Padded",
+    layout: new HorizontalLayout({spacing: 6}),
+    submorphs: [m]
+  };
+}
+
+class GridLayoutWithPadding extends GridLayout {
+  constructor(grid) {
+    super({grid: grid.reduce((rowCells, row) => {
+      const r = row.reduce((cells, cell) => cells.concat([cell, null]), [null]);
+      return rowCells.concat([r, Array(grid[0].length).map(_ => null)]);
+    }, [Array(grid[0].length).map(_ => null)])});
+  }
+  setupPadding(padding) {
+    for (let i = 0; i < this.rowCount; i += 2) {
+      this.row(i).fixed = padding;
+    }
+    for (let j = 0; j < this.columnCount; j += 2) {
+      this.col(j).fixed = padding;
+    }
+  }
+}
+
+class CommitGraph {
+  
+  constructor(pkg, numCommits) {
+    this.pkg = pkg;
+    this.numCommits = numCommits;
+    
+    this.queue = []; // Array<Commit>
+    this.commits = {}; // { [Hash]: {commit: Commit, branches: Array<Branch> }
+
+    this.nodes = []; // Array<{x, y, commit: Commit, branches: Array<Branch>, active: boolean }>
+    this.layers = {}; // { [number]: Array<{commit: Commit, branches: Array<Branch> }>}
+    this.edges = []; // Array<{x1, y1, x2, y2}>
+  }
+
+  addCommit(commit, branches = [], active = false) {
+    if (commit.hash in this.commits) {
+      const c = this.commits[commit.hash];
+      c.branches = arr.union(c.branches, branches);
+      if (active) c.active = true;
+      return;
+    }
+    
+    this.commits[commit.hash] = {commit, branches, active};
+    this.queue.push(commit);
+  }
+
+  async gatherCommits() {
+    // -> { [Hash]: Commit }
+    const active = await activeCommit(this.pkg),
+          branches = await localBranchesOf(this.pkg);
+    if (this.numCommits === null) {
+      this.numCommits = 3 * branches.length;
+    }
+    for (let i = 0; i < branches.length; i++) {
+      const branchHead = await branches[i].head();
+      this.addCommit(branchHead, [branches[i]]);
+    }
+    if (active) this.addCommit(active, [], true);
+    
+    let toShow = this.numCommits;
+    while (this.queue.length > 0) {
+      const next = this.queue.shift();
+      for (let p of next.parents) {
+        if (--toShow >= 0) {
+          this.addCommit(await commit(this.pkg, p));
+        }
+      }
+    }
+  }
+  
+  networkFlow(commitEntry) {
+    // { commit, y } -> Bool
+    for (let hash of commitEntry.commit.parents) {
+      if (!(hash in this.commits)) continue;
+      if (this.networkFlow(this.commits[hash])) {
+        return true;
+      } else if (this.commits[hash].y <= commitEntry.y) {
+        this.commits[hash].y++;
+        return true;
+      }
+    }
+    // maybe inc my own y
+    let minY = Number.MAX_SAFE_INTEGER;
+    for (let hash of commitEntry.commit.parents) {
+      if (!(hash in this.commits)) {
+        minY = 0;
+        break;
+      }
+      minY = Math.min(minY, this.commits[hash].y);
+    }
+    if (commitEntry.commit.parents.length > 0 && commitEntry.y < minY - 1) {
+      commitEntry.y = minY - 1;
+      return true;
+    }
+    
+    // no more flows possible
+    return false;
+  }
+  
+  determineLayers() {
+    Object.keys(this.commits).forEach(hash => this.commits[hash].y = 0);
+    const pseudoRoot = { commit: { parents: Object.keys(this.commits) }, y: 0 };
+    while (this.networkFlow(pseudoRoot));
+    this.nodes = Object.keys(this.commits).map(hash => this.commits[hash]);
+    if (this.nodes.length === 0) return;
+    const maxY = arr.max(this.nodes, ({y}) => y).y;
+    this.nodes.forEach(ce => ce.y = maxY - ce.y);
+    this.layers = arr.groupBy(this.nodes, ce => ce.y);
+  }
+  
+  determineColumns() {
+    const assignedColumns = Object.keys(this.layers).map(x => ({}));
+    for (let layerIdx = Object.keys(this.layers).length - 1; layerIdx >= 0; layerIdx--) {
+      const layer = this.layers[layerIdx];
+      // assign columns to non-assigned nodes in this layer
+      for (let commitEntry of layer) {
+        if (commitEntry.x !== undefined) continue;
+        let idx = 0;
+        while (assignedColumns[layerIdx][idx]) idx++;
+        commitEntry.x = idx;
+        assignedColumns[layerIdx][idx] = true;
+      }
+      // try to push column idx to direct parent, blocking column range
+      for (let commitEntry of layer) {
+        const pe = this.commits[commitEntry.commit.parents[0]];
+        if (pe && pe.x === undefined) {
+          pe.x = commitEntry.x;
+          for (let bIdx = layerIdx - 1; bIdx >= pe.y; bIdx--) {
+            assignedColumns[bIdx][pe.x] = true;
+          }
+        }
+      }
+    }
+  }
+  
+  createEdges() {
+    for (let node of this.nodes) {
+      for (let pNodeHash of node.commit.parents) {
+        if (pNodeHash in this.commits) {
+          const pNode = this.commits[pNodeHash];
+          this.edges.push({x1: pNode.x, y1: pNode.y, x2: node.x, y2: node.y});
+        }
+      }
+    }
+  }
+  
+  doLayout() {
+    this.determineLayers();
+    this.determineColumns();
+    this.createEdges();
+  }
+  
+  buildGraph() {
+    return this.gatherCommits().then(() => this.doLayout());
+  }
+}
+
+class CommitNode extends Morph {
+  
+  constructor(props) {
+    super({
+      extent: pt(160, 40),
+      borderWidth: 1,
+      borderRadius: 5,
+      fill: this.color(props.selected),
+      borderColor: props.active ? Color.black : this.color(props.selected),
+      tooltip: this.commitTooltip(props.commit),
+      submorphs: [
+        this.avatar(props.commit),
+        this.description(props.commit, props.selected),
+        ...this.branchTags(props.branches)
+      ],
+      ...props
+    });
+  }
+  
+  avatar(commit) {
+    const hash = lively.lang.string.md5(commit.author.email),
+          imageUrl = `https://www.gravatar.com/avatar/${hash}?s=32`;
+    return {
+      type: "image",
+      position: pt(4, 4),
+      extent: pt(32, 32),
+      tooltip: this.commitTooltip(commit),
+      imageUrl
+    };
+  }
+  
+  color(selected) {
+    return selected ? Color.rgb(180, 210, 229) : Color.rgb(229, 229, 229);
+  }
+
+  description(commit, selected) {
+    const date = new Date(commit.author.date.seconds * 1000),
+          relDate = lively.lang.date.relativeTo(date, new Date()),
+          msg = lively.lang.string.truncate(commit.message.replace(/\n/g, ' '), 20),
+          from = { row: 0, column: 0 },
+          to = { row: 1, column: 0 };
+    return {
+      type: "text",
+      position: pt(38, 6),
+      extent: pt(60, 18),
+      fill: this.color(selected),
+      tooltip: this.commitTooltip(commit),
+      fontSize: 10,
+      textString: `${msg}\n${commit.hash.substr(0, 8)} (${relDate})`,
+      styleRanges: [StyleRange.fromPositions({fontWeight: "bold"}, from, to)]
+    };
+  }
+  
+  branchTags(branches) {
+    return branches.map((branch, idx) => ({
+      position: pt(90 * idx + 5, -9),
+      type: "text",
+      fontSize: 10,
+      fontColor: Color.white,
+      fill: Color.darkGray,
+      textString: branch.name
+    }));
+  }
+  
+  commitTooltip(commit) {
+    const date = new Date(commit.author.date.seconds * 1000),
+          humanDate = lively.lang.date.format(date),
+          relDate = lively.lang.date.relativeTo(date, new Date());
+    return `${commit.message}\n${commit.hash}\n\n${commit.author.name} (${commit.author.email})\n${relDate} ago (${humanDate})`
+  }
+  
+  onMouseDown(evt) {
+    if (!this.selected) this.owner.selectCommit(this);
+  }
+
+}
+
+class CommitTree extends Morph {
+
+  constructor(props) {
+    super({
+      clipMode: "auto",
+      ...props
+    });
+    this.toShow = null;
+    this.selectedCommit = null;
+    this.selectedBranch = null;
+  }
+  
+  addNode(x, y, commit, branches, selected, active) {
+    this.addMorph(new CommitNode({
+      commit, branches, selected, active, position: pt(x * 180 + 10, y * 60 + 10)
+    }));
+  }
+  
+  addEdge(x1, y1, x2, y2) {
+    const mx = (x2 - x1) * 180 + 3,
+          my = (y2 - y1) * 60 - 40,
+          topLeft = pt(Math.min(x1, x2) * 180 + 87, y1 * 60 + 50),
+          xOffset = Math.max(0, x1 - x2) * 180 + 3;
+    this.addMorph(morph({
+      type: "path",
+      position: topLeft,
+      extent: pt(Math.abs(x2 - x1) * 180 + 3 + 6, my),
+      borderColor: Color.rgb(112,112,112),
+      borderWidth: 2,
+      vertices: [{x: xOffset,y:0}, {x:xOffset,y:10}, {x:mx,y:10}, {x:mx,y:my}, {x:mx+3,y:my-6}, {x:mx,y:my}, {x:mx-3,y:my-6}, {x:mx,y:my}]
+    }));
+  }
+  
+  addLoadMoreButton() {
+    const btn = morph({
+      type: "button",
+      label: "load more",
+      position: pt(0, 0),
+      fontSize: 11,
+      borderRadius: 0,
+      extent: pt(70, 20)
+    });
+    this.addMorph(btn);
+    connect(btn, "fire", this, "loadMore");
+  }
+  
+  loadMore() {
+    if (this.numCommits === null) return;
+    this.numCommits += 10;
+    return this.update();
+  }
+
+  async update(pkg = this.pkg) {
+    if (this.pkg !== pkg) this.numCommits = null;
+    this.pkg = pkg;
+    const prevSelectedCommit = this.selectedCommit,
+          prevSelectedBranch = this.selectedBranch;
+    this.selectedCommit = null;
+    this.selectedBranch = null;
+    this.removeAllMorphs();
+    if (!pkg) return;
+    this.addMorph({type: "text", textString: "loading..."});
+    const graph = new CommitGraph(pkg, this.numCommits);
+    await graph.buildGraph();
+    this.numCommits = graph.nodes.length;
+    this.removeAllMorphs();
+    for (let {x, y, commit, branches, active} of graph.nodes) {
+      const selected = prevSelectedCommit && prevSelectedCommit.hash === commit.hash;
+      this.addNode(x, y, commit, branches, selected, active);
+      if (selected) {
+        this.selectedCommit = commit;
+        this.selectedBranch = branches[0] || null;
+      }
+    }
+    for (let {x1, y1, x2, y2} of graph.edges) {
+      this.addEdge(x1, y1, x2, y2);
+    }
+    if (this.submorphs.length > 0) {
+      this.addLoadMoreButton();
+    }
+  }
+  
+  selectCommit(node) {
+    // CommitNode -> ()
+    this.selectedCommit = node.commit;
+    this.selectedBranch = node.branches[0] || null;
+    this.update().then(() => signal(this, "selection", node.commit));
+  }
+
+}
+
+export default class VersionControl extends Window {
+
+  constructor(props) {
+    super({
+      name: "VersionControl",
+      extent: pt(850,600),
+      ...props,
+      targetMorph: this.content()
+    });
+    this.reset();
+    this.updatePackageList();
+    connect(this.get("packageList"), "selection", this, "updateCommitTree");
+    connect(this.get("commitTree"), "selection", this, "updateCommitPanel");
+    connect(this.get("allChkBox"), "toggle", this, "toggleShowChanges");
+    connect(this.get("changedChkBox"), "toggle", this, "toggleShowChanges");
+    connect(this.get("fileList"), "selection", this, "updateEditor");
+    connect(this.get("loadBtn"), "fire", this, "loadCommit");
+    connect(this.get("commitBtn"), "fire", this, "createCommit");
+    connect(this.get("branchBtn"), "fire", this, "createBranch");
+    connect(this.get("pushBtn"), "fire", this, "pushBranch");
+    connect(this.get("pullBtn"), "fire", this, "pullBranch");
+    connect(this.get("configBtn"), "fire", this, "config");
+    this.subscribe(true);
+  }
+
+  content() {
+    var style = {fill: Color.rgb(243, 243, 243), borderWidth: 6, borderColor: Color.rgb(243, 243, 243), borderRadius: 6};
+    const m = morph({
+      fill: Color.white,
+      layout: new GridLayoutWithPadding(
+              [["packageList", "commitTree"],
+               ["filePanel", "commitPanel"],
+               ["fileList", "sourceEditor"]]),
+      submorphs: [
+        {name: "packageList", type: "list", ...style},
+        {name: "commitTree", type: CommitTree, ...style},
+        this.filePanel(style),
+        this.commitPanel(style),
+        {name: "fileList", type: "list", ...style},
+        {name: "sourceEditor", type: CodeEditor}
+      ]
+    });
+    m.layout.setupPadding(6);
+    m.layout.col(1).fixed = 180;
+    m.layout.row(3).fixed = 24;
+    return m;
+  }
+  
+  filePanel(style) {
+    const labelStyle = {fontSize: 11};
+    return morph({
+      name: "filePanel",
+      layout: new HorizontalLayout({spacing: 6}),
+      submorphs: [
+        {type: "text", textString: "show:", ...labelStyle},
+        {name: "allChkBox", type: "checkbox", extend: pt(16,16), checked: false},
+        {type: "text", textString: "all", ...labelStyle},
+        {name: "changedChkBox", type: "checkbox", extend: pt(16,16), checked: true},
+        {type: "text", textString: "changed", ...labelStyle}
+      ]
+    });
+  }
+
+  commitPanel(style) {
+    const btnStyle = {fontSize: 11, borderRadius: 0, extent: pt(40, 20)};
+    return morph({
+      name: "commitPanel",
+      layout: new HorizontalLayout({spacing: 6}),
+      submorphs: [
+        {type: "button", label: "load", name: "loadBtn", ...btnStyle},
+        {type: "button", label: "commit", name: "commitBtn", ...btnStyle},
+        {type: "button", label: "branch", name: "branchBtn", ...btnStyle},
+        {type: "button", label: "push", name: "pushBtn", ...btnStyle},
+        {type: "button", label: "pull", name: "pullBtn", ...btnStyle},
+        {type: "button", label: "config", name: "configBtn", ...btnStyle}
+      ]
+    });
+  }
+
+  reset() {
+    this.subscribe(false);
+    this.showChanges = true;
+    this.get("packageList").items = [];
+    this.get("fileList").items = [];
+    this.get("sourceEditor").textString = "";
+  }
+  
+  toggleShowChanges() {
+    this.showChanges = !this.showChanges;
+    this.get("allChkBox").checked = !this.showChanges;
+    this.get("changedChkBox").checked = this.showChanges;
+    return this.updateFileList();
+  }
+  
+  loadCommit() {
+    const selectedCommit = this.get("commitTree").selectedCommit;
+    if (!selectedCommit) return;
+    return selectedCommit.activate();
+  }
+  
+  async createCommit() {
+    const selectedBranch = this.get("commitTree").selectedBranch;
+    if (!selectedBranch) return;
+    const message = await this.world().prompt("Enter commit message", {
+      historyId: "ChangeSorter/message",
+      useLastInput: false
+    });
+    return selectedBranch.commitChanges(message);
+  }
+  
+  async createBranch() {
+    const pkg = this.get("packageList").selection,
+          selectedCommit = this.get("commitTree").selectedCommit;
+    if (!pkg || !selectedCommit) return;
+    const branchName = await this.world().prompt("Enter branch name", {
+      historyId: "ChangeSorter/branch",
+      useLastInput: false
+    });
+    const b = await branch(pkg.address, branchName);
+    return b.createFrom(selectedCommit);
+  }
+  
+  async config() {
+    const name = await this.world().prompt("Enter author name for commits", {
+      input: getAuthor().name,
+      historyId: "ChangeSorter/name",
+      useLastInput: false
+    });
+    const email = await this.world().prompt("Enter author email for commits", {
+      input: getAuthor().email,
+      historyId: "ChangeSorter/email",
+      useLastInput: false
+    });
+    return setAuthor({name, email});
+  }
+  
+  async enableGitHub() {
+    let token = getGitHubToken();
+    if (token !== '<secret>') return;
+    token = await this.world().prompt(
+      "Please enter your Personal Access Token for interacting with GitHub", {
+      historyId: 'lively.changesets/github-access-token',
+      useLastInput: true
+    });
+    setGitHubToken(token);
+  }
+  
+  pushBranch() {
+    const selectedBranch = this.get("commitTree").selectedBranch;
+    if (!selectedBranch) return;
+    return this.enableGitHub().then(() => selectedBranch.pushToGitHub());
+  }
+  
+  async pullBranch() {
+    const pkg = this.get("packageList").selection;
+    if (!pkg) return;
+    await this.enableGitHub();
+    const branches = await gitHubBranches(pkg.address);
+    const {selected: [branchName]} = await this.world().filterableListPrompt(
+      "Pull branch from GitHub",
+      branches.map(branch => branch.name));
+    const b = await branch(pkg.address, branchName);
+    return b.pullFromGitHub();
+  }
+  
+  updatePackageList() {
+    this.get("packageList").items = localInterface.getPackages().map(p =>
+      ({isListItem: true, string: p.name, value: p}));
+    return this.updateCommitTree();
+  }
+  
+  updateCommitTree() {
+    const pkg = this.get("packageList").selection || null;
+    return this.get("commitTree").update(pkg && pkg.address)
+      .then(() => this.updateCommitPanel());
+  }
+  
+  async updateCommitPanel() {
+    const selectedCommit = this.get("commitTree").selectedCommit;
+    const selectedBranch = this.get("commitTree").selectedBranch;
+    this.get("loadBtn").active = !!selectedCommit;
+    this.get("commitBtn").active = !!selectedBranch;
+    this.get("branchBtn").active = !!selectedCommit;
+    this.get("pushBtn").active = !!selectedBranch;
+    this.get("pullBtn").active = !!this.get("packageList").selection;
+    return this.updateFileList();
+  }
+  
+  async updateFileList() {
+    const fileList = this.get("fileList"),
+          selectedCommit = this.get("commitTree").selectedCommit;
+    let files;
+    if (!selectedCommit) {
+      files = {};
+    } else if (this.showChanges) {
+      files = await selectedCommit.changedFiles();
+    } else {
+      files = await selectedCommit.files();
+    }
+    // FIXME work-around b/c list doesn't preserve selection when updating items
+    const prevSelected = fileList.selection;
+    fileList.items = Object.keys(files).map(fname => ({
+      isListItem: true,
+      string: fname,
+      value: fname
+    }));
+    fileList.selection = fileList.items.find(i => i.value === prevSelected);
+    return this.updateEditor();
+  }
+  
+  async updateEditor() {
+    const editor = this.get("sourceEditor"),
+          selectedCommit = this.get("commitTree").selectedCommit,
+          selectedFile = this.get("fileList").selection;
+    let content;
+    if (!selectedCommit || !selectedFile) {
+      content = "";
+    } else if (this.showChanges) {
+      content = await selectedCommit.diffFile(selectedFile);
+    } else {
+      content = await selectedCommit.getFileContent(selectedFile);
+    }
+    editor.textString = content;
+    editor.mode = this.showChanges ? "diff" : "javascript";
+  }
+  
+  subscribe(sub) {
+    if (!this._update) {
+      this._update = this.updatePackageList.bind(this);
+    }
+    unsubscribe("lively.changesets/branchadded", this._update);
+    unsubscribe("lively.changesets/branchdeleted", this._update);
+    unsubscribe("lively.changesets/branchpushed", this._update);
+    unsubscribe("lively.changesets/branchpulled", this._update);
+    unsubscribe("lively.changesets/activated", this._update);
+    unsubscribe("lively.changesets/deactivated", this._update);
+    unsubscribe("lively.changesets/changed", this._update);
+    unsubscribe("lively.modules/packageregistered", this._update);
+    unsubscribe("lively.modules/packageremoved", this._update);
+    if (sub) {
+      subscribe("lively.changesets/branchadded", this._update);
+      subscribe("lively.changesets/branchdeleted", this._update);
+      subscribe("lively.changesets/branchpushed", this._update);
+      subscribe("lively.changesets/branchpulled", this._update);
+      subscribe("lively.changesets/activated", this._update);
+      subscribe("lively.changesets/deactivated", this._update);
+      subscribe("lively.changesets/changed", this._update);
+      subscribe("lively.modules/packageregistered", this._update);
+      subscribe("lively.modules/packageremoved", this._update);
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ export { show } from "./markers.js"
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 import { World } from "./world.js";
-import { Morph, Hand, Image, Ellipse } from "./morph.js";
+import { Morph, Hand, Image, Ellipse, Path } from "./morph.js";
 import { List } from "./list.js";
 import { Text } from "./text/morph.js";
-import { Button } from "./widgets.js";
+import { Button, CheckBox } from "./widgets.js";
 
 export function morph(props = {}, opts = {restore: false}) {
   var klass = Morph;
@@ -27,9 +27,11 @@ export function morph(props = {}, opts = {restore: false}) {
         case 'hand':    klass = Hand; break;
         case 'image':   klass = Image; break;
         case 'ellipse': klass = Ellipse; break;
+        case 'path':    klass = Path; break;
         case 'text':    klass = Text; break;
         case 'list':    klass = List; break;
         case 'button':  klass = Button; break;
+        case 'checkbox':klass = CheckBox; break;
       }
   }
 

--- a/widgets.js
+++ b/widgets.js
@@ -238,15 +238,17 @@ export class Button extends Morph {
     return {
       borderColor: Color.gray,
       fill: Color.rgb(240,240,240),
-      fontColor: Color.almostBlack
+      fontColor: Color.almostBlack,
+      nativeCursor: "pointer"
     }
   }
 
   get inactiveStyle() {
     return {
-      borderColor: Color.darkGray,
-      fill: Color.gray,
-      fontColor: Color.darkGray
+      borderColor: Color.gray.withA(0.5),
+      fill: Color.rgba(240,240,240, 0.5),
+      fontColor: Color.almostBlack.withA(0.5),
+      nativeCursor: "not-allowed"
     }
   }
 
@@ -283,6 +285,7 @@ export class Button extends Morph {
   get active() { return this.getProperty("active"); }
   set active(value) {
     Object.assign(this, value ? this.activeStyle : this.inactiveStyle);
+    this.submorphs[0].nativeCursor = this.nativeCursor;
     this.addValueChange("active", value);
   }
 
@@ -337,8 +340,8 @@ export class CheckBox extends Morph {
 
   trigger() {
     try {
-      signal(this, "checked", !this.checked);
       this.checked = !this.checked;
+      signal(this, "toggle", this.checked);
     } catch (err) {
       var w = this.world();
       if (w) w.logError(err);


### PR DESCRIPTION
This PR adds a version control widget based on `lively.changesets`. In contrast to the ChangeSorter, this tool is designed around the typical git workflow.
- [x] lists all packages, uses package.json to find repository information
- [x] loads git commit history from in-browser IndexedDB, the lively server or GitHub (in that order)
- [x] visualizes network of commits with an unlimited number of branches
- [x] allows navigation back in time through commit history
- [x] enables loading of particular commits (based on `lively.modules` and `lively.vm`)
- [x] if the commit is the head of a branch and its message is "work in progress", all writes will be intercepted and become part of the commit
- [x] can create new commits with given commit message, author name and email
- [x] can create new branches based on any existing commits or branches
- [x] branches can be pushed to GitHub (**be careful: this is always a `push -f`**)
- [x] branches can be imported from GitHub (**be careful: this overwrites any local changes**)
- [ ] commits cannot be reordered or rebased
- [ ] changes cannot be merged and conflicts not resolved

![version-control](https://cloud.githubusercontent.com/assets/479238/18904297/3930e1c6-8512-11e6-9a90-571b234d35c0.png)
