### PR TITLE
Text line wrapping

### DIFF
--- a/config.js
+++ b/config.js
@@ -183,6 +183,7 @@ var config = {
       {keys: "Ctrl-Space", command: "toggle active mark"},
 
 
+      {keys: {mac: 'Meta-Shift-L L T'}, command: "toggle line wrapping"},
       {keys: {win: 'Ctrl-=', mac: 'Meta-='}, command: "increase font size"},
       {keys: {win: 'Ctrl--', mac: 'Meta--'}, command: "decrease font size"},
 

--- a/rendering/font-metric.js
+++ b/rendering/font-metric.js
@@ -71,15 +71,11 @@ export default class FontMetric {
     this.element.style.fontWeight = fontWeight,
     this.element.style.fontStyle = fontStyle,
     this.element.style.textDecoration = textDecoration;
+    var width, height;
     try {
-      rect = this.element.getBoundingClientRect();
-    } catch(e) {
-      rect = {width: 0, height:0};
-    };
-    return {
-      height: rect.height,
-      width: rect.width
-    }
+      ({width, height} = this.element.getBoundingClientRect());
+    } catch(e) { return {width: 0, height:0}; };
+    return {height, width}
   }
 
   charBoundsFor(style, str) {

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -10,11 +10,11 @@ export var dummyFontMetric = {
     return text.split('').map(function (char, col) {
       let x = prevX,
           { width, height } = this;
-      if (col === text.length - 1) width = 0;
       prevX += width;
       return { x, y: 0, width, height };
     }, this);
-  }
+  },
+  defaultLineHeight(style) { return this.height; }
 }
 
 export function expectSelection(chai) {

--- a/tests/text-test.js
+++ b/tests/text-test.js
@@ -183,7 +183,7 @@ describe("scroll", () => {
     expect(sut.scroll).equals(pt(0,2*lineHeight+padTop));
     sut.cursorPosition = {column: 0, row: 0};
     sut.scrollCursorIntoView();
-    expect(sut.scroll).equals(pt(0,0))
+    expect(sut.scroll).equals(pt(0,padTop))
   });
 
 });

--- a/tests/text-test.js
+++ b/tests/text-test.js
@@ -255,9 +255,9 @@ describe("text mouse events", () => {
     expect(sut.selection).selectionEquals("Selection(0/0 -> 0/0)");
     env.eventDispatcher.simulateDOMEvents({target: sut, type: "click", position: clickPos});
 
-    var clickIndex = sut.document.positionToIndex({row: 1, column: 2});
-    expect(clickIndex).equals(7);
-    expect(sut.selection).selectionEquals("Selection(1/2 -> 1/2)");
+    var clickIndex = sut.document.positionToIndex({row: 1, column: 3});
+    expect(clickIndex).equals(8);
+    expect(sut.selection).selectionEquals("Selection(1/3 -> 1/3)");
   });
 
   it("double-click selects word", () => {
@@ -472,5 +472,40 @@ describe("text movement and selection commands", () => {
     });
 
   });
+
+  it("get position above and below with line wrapping", () => {
+
+    var {width: charWidth,height: charHeight} = fontMetric;
+    var padding = Rectangle.inset(3);
+    var t = text("a\ncdefg\n", {
+      extent: pt(3*charWidth + padding.left() + padding.right(), 200),
+      lineWrapping: true,
+      clipMode: "hidden"
+    });
+
+    t.cursorPosition = {column: 5,row: 1};
+    expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "before 1");
+
+    t.selection.goUp(1, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 1, column: 2}, "up wrapped line 1");
+    expect(t.cursorPosition).deep.equals({row: 1, column: 2}, "up wrapped line 2");
+
+    t.selection.goUp(1, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 0, column: 1}, "upped simple line ");
+
+    t.selection.goDown(3, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 3, column: 0}, "down into wrapped");
+
+    t.selection.goUp(1, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "up again from empty line");
+
+    t.cursorPosition = {row: 3, column: 0}
+    t.selection.goUp(1, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 2, column: 0}, "up from empty line with goal column set to it");
+
+    t.cursorScreenPosition = {row: 2, column: 1}
+    t.selection.goUp(1, true);
+    expect(t.cursorScreenPosition).deep.equals({row: 1, column: 1}, "up from wrapped line with goal column set to it");
+  })
 
 });

--- a/tests/text-test.js
+++ b/tests/text-test.js
@@ -255,9 +255,9 @@ describe("text mouse events", () => {
     expect(sut.selection).selectionEquals("Selection(0/0 -> 0/0)");
     env.eventDispatcher.simulateDOMEvents({target: sut, type: "click", position: clickPos});
 
-    var clickIndex = sut.document.positionToIndex({row: 1, column: 3});
-    expect(clickIndex).equals(8);
-    expect(sut.selection).selectionEquals("Selection(1/3 -> 1/3)");
+    var clickIndex = sut.document.positionToIndex({row: 1, column: 2});
+    expect(clickIndex).equals(7);
+    expect(sut.selection).selectionEquals("Selection(1/2 -> 1/2)");
   });
 
   it("double-click selects word", () => {

--- a/tests/text/layout-test.js
+++ b/tests/text/layout-test.js
@@ -1,22 +1,30 @@
 /*global System, declare, it, xit, describe, xdescribe, beforeEach, afterEach, before, after*/
 import { Text } from "../../text/morph.js";
+import { TextAttribute } from "../../text/style.js";
 import { expect } from "mocha-es6";
 import { pt, Color, Rectangle, Transform, rect } from "lively.graphics";
 import { dummyFontMetric as fontMetric } from "../test-helpers.js";
 
-const padding = 20;
 
+var padding = Rectangle.inset(5);
+
+var w, h;
 function text(string, props) {
-  return new Text({
+  var t = new Text({
     name: "text",
     textString: string,
     fontFamily: "Monaco, monospace",
     fontSize: 10,
     extent: pt(100,100),
     padding,
-    fontMetric,
+    // fontMetric,
+    fontMetric: $$world.env.fontMetric,
+    // textLayout: new TextLayout(fontMetric),
+    // textRenderer: newRenderer,
     ...props
   });
+  ([{height:h, width:w}] = t.textLayout.fontMetric.charBoundsFor(t.styleProps, "X"));
+  return t;
 }
 
 
@@ -25,21 +33,20 @@ describe("text layout", () => {
   describe("fit", () => {
 
     it("computes size on construction", () => {
-      var t = text("hello", {fixedWidth: false, fixedHeight: false}),
-          {extent: {x: width, y: height}} = text("hello", {fixedWidth: false, fixedHeight: false});
-      expect(height).equals(fontMetric.height + 2*padding);
-      expect(width).equals(5*fontMetric.width + 2*padding);
+      var t = text("hello", {fixedWidth: false, fixedHeight: false}), {width, height} = t;
+      expect(height).equals(h + padding.top()+ padding.bottom());
+      expect(width).equals(5*w + padding.left()+ padding.right());
     });
 
     it("computes only width", () => {
       var {extent: {x: width, y: height}} = text("hello", {fixedWidth: false, fixedHeight: true});
       expect(height).equals(100);
-      expect(width).equals(5*fontMetric.width + 2*padding);
+      expect(width).equals(5*w + padding.top()+ padding.bottom());
     });
 
     it("computes only height", () => {
       var {extent: {x: width, y: height}} = text("hello", {fixedWidth: true, fixedHeight: false});
-      expect(height).equals(fontMetric.height + 2*padding);
+      expect(height).equals(h + padding.top()+ padding.bottom());
       expect(width).equals(100);
     });
 
@@ -53,11 +60,10 @@ describe("text layout", () => {
 
   describe("positions", () => {
 
-    var t, r, w, h;
+    var t, r;
     beforeEach(() => {
       t = text("hello\n lively\nworld");
       r = t.textLayout;
-      ({height:h, width:w} = fontMetric);
     });
 
     it("text pos -> pixel pos", () => {
@@ -84,6 +90,86 @@ describe("text layout", () => {
       expect(t.textPositionFromPoint(pt(w*2+1,h*2+1)))    .deep.equals({row: 2, column: 2});
       expect(t.textPositionFromPoint(pt(w*2+w/2+1,h*2+1))).deep.equals({row: 2, column: 3}, "right side of char -> next pos")
     });
+
+  });
+
+});
+
+
+describe("line wrapping", () => {
+
+  var t;
+
+  it("wraps single line and computes positions back and forth", () => {
+    t = text("", {
+      padding: Rectangle.inset(0), borderWidth: 0, fill: Color.red,
+      lineWrapping: false, clipMode: "auto",
+      width: 4*w, textString: "abcdef\n1234567"
+    });
+
+    var l = t.textLayout;
+
+    t.textLayout.updateFromMorphIfNecessary(t);
+
+    expect(l.lines).to.have.length(2);
+    expect(l.wrappedLines(t)).to.have.length(2);
+    expect(t.charBoundsFromTextPosition({row: 0, column: 5})).equals(rect(w*5,0,w,h), "not wrapped: text pos => pixel pos");
+    expect(t.textPositionFromPoint(pt(2*w+1, h+1))).deep.equals({column: 2,row: 1}, "not wrapped: pixel pos => text pos");
+
+    t.lineWrapping = true;
+    expect(l.wrappedLines(t)).to.have.length(4);
+
+    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(w*4,0,0,h), "wrapped: text pos => pixel pos 1");
+    expect(l.boundsForScreenPos(t, {row: 0, column: 5})).equals(rect(w*4,0,0,h), "wrapped: text pos => pixel pos 2");
+    expect(l.boundsForScreenPos(t, {row: 1, column: 1})).equals(rect(w*1,h,w,h), "wrapped: pixel pos => text pos 3");
+    expect(l.boundsForScreenPos(t, {row: 3, column: 1})).equals(rect(w*1,3*h,w,h), "wrapped: pixel pos => text pos 4");
+    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(w*4,0,0,h), "wrapped: pixel pos => text pos 5");
+
+    expect(l.docToScreenPos(t, {row: 0, column: 4})).deep.equals({row: 1, column: 0}, "doc => screen pos 1");
+    expect(l.docToScreenPos(t, {row: 0, column: 5})).deep.equals({row: 1, column: 1}, "doc => screen pos 2");
+    expect(l.docToScreenPos(t, {row: 0, column: 6})).deep.equals({row: 1, column: 2}, "doc => screen pos 3");
+    expect(l.docToScreenPos(t, {row: 1, column: 1})).deep.equals({row: 2, column: 1}, "doc => screen pos 4");
+    expect(l.docToScreenPos(t, {row: 1, column: 6})).deep.equals({row: 3, column: 2}, "doc => screen pos 5");
+
+    expect(l.screenToDocPos(t, {row: 0, column: 1})).deep.equals({row: 0, column: 1}, "screen => doc line 1 pos 1");
+    // at screen line end...
+    expect(l.screenToDocPos(t, {row: 0, column: 4})).deep.equals({row: 0, column: 4}, "screen => doc line 1 pos 2");
+    // ...at screen line start, note, it's the same position as line end for the document!
+    expect(l.screenToDocPos(t, {row: 0, column: 5})).deep.equals({row: 0, column: 4}, "screen => doc line 1 pos 3");
+    expect(l.screenToDocPos(t, {row: 1, column: 0})).deep.equals({row: 0, column: 4}, "screen => doc line 1 pos 4");
+    expect(l.screenToDocPos(t, {row: 1, column: 1})).deep.equals({row: 0, column: 5}, "screen => doc line 1 pos 5");
+    expect(l.screenToDocPos(t, {row: 1, column: 2})).deep.equals({row: 0, column: 6}, "screen => doc line 1 pos 6");
+    expect(l.screenToDocPos(t, {row: 1, column: 3})).deep.equals({row: 0, column: 6}, "screen => doc line 1 pos 7");
+
+    expect(l.screenToDocPos(t, {row: 2, column: 0})).deep.equals({row: 1, column: 0}, "screen => doc pos line 2 1");
+    expect(l.screenToDocPos(t, {row: 2, column: 3})).deep.equals({row: 1, column: 3}, "screen => doc pos line 2 2");
+    expect(l.screenToDocPos(t, {row: 2, column: 4})).deep.equals({row: 1, column: 4}, "screen => doc pos line 2 3");
+    expect(l.screenToDocPos(t, {row: 2, column: 5})).deep.equals({row: 1, column: 4}, "screen => doc pos line 2 4");
+    expect(l.screenToDocPos(t, {row: 3, column: 0})).deep.equals({row: 1, column: 4}, "screen => doc pos line 2 5");
+    expect(l.screenToDocPos(t, {row: 3, column: 1})).deep.equals({row: 1, column: 5}, "screen => doc pos line 2 6");
+    expect(l.screenToDocPos(t, {row: 3, column: 3})).deep.equals({row: 1, column: 7}, "screen => doc pos line 2 7");
+    expect(l.screenToDocPos(t, {row: 3, column: 4})).deep.equals({row: 1, column: 7}, "screen => doc pos line 2 8");
+
+    expect(l.screenToDocPos(t, {row: 4, column: 0})).deep.equals({row: 1, column: 7}, "screen => doc pos after text");
+  });
+
+  it("wraps attribute line", () => {
+
+    var textAttributes = [
+      TextAttribute.create({fontColor: "blue"}, 0,0,0,3),
+      TextAttribute.create({fontColor: "green"}, 0,3,0,6)]
+
+    t = text("", {
+      padding: Rectangle.inset(0), borderWidth: 0, fill: Color.red,
+      lineWrapping: true, clipMode: "auto",
+      width: 4*w, textString: "abcdef",
+      textAttributes
+    });
+
+    var wrappedLines = t.textLayout.wrappedLines(t)
+    expect(wrappedLines[0].chunks[0]).containSubset({text: "abc"});
+    expect(wrappedLines[0].chunks[1]).containSubset({text: "d"});
+    expect(wrappedLines[1].chunks[0]).containSubset({text: "ef"});
 
   });
 

--- a/tests/text/layout-test.js
+++ b/tests/text/layout-test.js
@@ -17,8 +17,8 @@ function text(string, props) {
     fontSize: 10,
     extent: pt(100,100),
     padding,
-    // fontMetric,
-    fontMetric: $$world.env.fontMetric,
+    fontMetric,
+    // fontMetric: $$world.env.fontMetric,
     // textLayout: new TextLayout(fontMetric),
     // textRenderer: newRenderer,
     ...props

--- a/tests/text/layout-test.js
+++ b/tests/text/layout-test.js
@@ -60,35 +60,39 @@ describe("text layout", () => {
 
   describe("positions", () => {
 
-    var t, r;
+    var t, r, padl, padr, padt, padb;
     beforeEach(() => {
       t = text("hello\n lively\nworld");
       r = t.textLayout;
+      padl = padding.left();
+      padr = padding.right();
+      padt = padding.top();
+      padb = padding.bottom();
     });
 
     it("text pos -> pixel pos", () => {
-      expect(r.pixelPositionFor(t, {row: 0, column: 0}))    .equals(pt(0,   0));
-      expect(r.pixelPositionFor(t, {row: 0, column: 5}))    .equals(pt(5*w, 0));
-      expect(r.pixelPositionFor(t, {row: 1, column: 0}))    .equals(pt(0,   h));
-      expect(r.pixelPositionFor(t, {row: 1, column: 1}))    .equals(pt(1*w, h));
-      expect(r.pixelPositionFor(t, {row: 3, column: 2}))    .equals(pt(2*w, 2*h));
-      expect(r.pixelPositionFor(t, {row: 1, column: 100}))  .equals(pt(7*w, h));
-      expect(r.pixelPositionFor(t, {row: 100, column: 100})).equals(pt(5*w, 2*h));
+      expect(r.pixelPositionFor(t, {row: 0, column: 0}))    .equals(pt(padl+0,   padt+0));
+      expect(r.pixelPositionFor(t, {row: 0, column: 5}))    .equals(pt(padl+5*w, padt+0));
+      expect(r.pixelPositionFor(t, {row: 1, column: 0}))    .equals(pt(padl+0,   padt+h));
+      expect(r.pixelPositionFor(t, {row: 1, column: 1}))    .equals(pt(padl+1*w, padt+h));
+      expect(r.pixelPositionFor(t, {row: 3, column: 2}))    .equals(pt(padl+2*w, padt+2*h));
+      expect(r.pixelPositionFor(t, {row: 1, column: 100}))  .equals(pt(padl+7*w, padt+h));
+      expect(r.pixelPositionFor(t, {row: 100, column: 100})).equals(pt(padl+5*w, padt+2*h));
     });
 
     it("text index -> pixel pos", () => {
-      expect(r.pixelPositionForIndex(t, 0)).equals(pt(0,0));
-      expect(r.pixelPositionForIndex(t, 6)).equals(pt(0,h));
-      expect(r.pixelPositionForIndex(t, 7)).equals(pt(w,h));
-      expect(r.pixelPositionForIndex(t, 100)).equals(pt(5*w,2*h));
+      expect(r.pixelPositionForIndex(t, 0)).equals(pt(padl+0,padt+0));
+      expect(r.pixelPositionForIndex(t, 6)).equals(pt(padl+0,padt+h));
+      expect(r.pixelPositionForIndex(t, 7)).equals(pt(padl+w,padt+h));
+      expect(r.pixelPositionForIndex(t, 100)).equals(pt(padl+5*w,padt+2*h));
     });
 
     it("pixel pos -> text pos", () => {
-      expect(t.textPositionFromPoint(pt(0,0)))            .deep.equals({row: 0, column: 0});
-      expect(t.textPositionFromPoint(pt(w-1,h/2)))        .deep.equals({row: 0, column: 1});
-      expect(t.textPositionFromPoint(pt(w+1,h+1)))        .deep.equals({row: 1, column: 1});
-      expect(t.textPositionFromPoint(pt(w*2+1,h*2+1)))    .deep.equals({row: 2, column: 2});
-      expect(t.textPositionFromPoint(pt(w*2+w/2+1,h*2+1))).deep.equals({row: 2, column: 3}, "right side of char -> next pos")
+      expect(t.textPositionFromPoint(pt(padl+0,         padt+0)))            .deep.equals({row: 0, column: 0});
+      expect(t.textPositionFromPoint(pt(padl+w-1,       padt+h/2)))        .deep.equals({row: 0, column: 1});
+      expect(t.textPositionFromPoint(pt(padl+w+1,       padt+h+1)))        .deep.equals({row: 1, column: 1});
+      expect(t.textPositionFromPoint(pt(padl+w*2+1,     padt+h*2+1)))    .deep.equals({row: 2, column: 2});
+      expect(t.textPositionFromPoint(pt(padl+w*2+w/2+1, padt+h*2+1))).deep.equals({row: 2, column: 3}, "right side of char -> next pos")
     });
 
   });
@@ -101,10 +105,15 @@ describe("line wrapping", () => {
   var t;
 
   it("wraps single line and computes positions back and forth", () => {
-    t = text("", {
-      padding: Rectangle.inset(0), borderWidth: 0, fill: Color.red,
+    var padl = padding.left(),
+        padr = padding.right(),
+        padt = padding.top(),
+        padb = padding.bottom();
+
+    t = text("abcdef\n1234567", {
+      padding, borderWidth: 0, fill: Color.red,
       lineWrapping: false, clipMode: "auto",
-      width: 4*w, textString: "abcdef\n1234567"
+      width: 4*w+padl+padr
     });
 
     var l = t.textLayout;
@@ -113,17 +122,17 @@ describe("line wrapping", () => {
 
     expect(l.lines).to.have.length(2);
     expect(l.wrappedLines(t)).to.have.length(2);
-    expect(t.charBoundsFromTextPosition({row: 0, column: 5})).equals(rect(w*5,0,w,h), "not wrapped: text pos => pixel pos");
-    expect(t.textPositionFromPoint(pt(2*w+1, h+1))).deep.equals({column: 2,row: 1}, "not wrapped: pixel pos => text pos");
+    expect(t.charBoundsFromTextPosition({row: 0, column: 5})).equals(rect(padl+w*5,padt,w,h), "not wrapped: text pos => pixel pos");
+    expect(t.textPositionFromPoint(pt(padl + 2*w+1, padt + h+1))).deep.equals({column: 2,row: 1}, "not wrapped: pixel pos => text pos");
 
     t.lineWrapping = true;
     expect(l.wrappedLines(t)).to.have.length(4);
 
-    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(w*4,0,0,h), "wrapped: text pos => pixel pos 1");
-    expect(l.boundsForScreenPos(t, {row: 0, column: 5})).equals(rect(w*4,0,0,h), "wrapped: text pos => pixel pos 2");
-    expect(l.boundsForScreenPos(t, {row: 1, column: 1})).equals(rect(w*1,h,w,h), "wrapped: pixel pos => text pos 3");
-    expect(l.boundsForScreenPos(t, {row: 3, column: 1})).equals(rect(w*1,3*h,w,h), "wrapped: pixel pos => text pos 4");
-    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(w*4,0,0,h), "wrapped: pixel pos => text pos 5");
+    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(padl+w*4,padt+0,0,h), "wrapped: text pos => pixel pos 1");
+    expect(l.boundsForScreenPos(t, {row: 0, column: 5})).equals(rect(padl+w*4,padt+0,0,h), "wrapped: text pos => pixel pos 2");
+    expect(l.boundsForScreenPos(t, {row: 1, column: 1})).equals(rect(padl+w*1,padt+h,w,h), "wrapped: pixel pos => text pos 3");
+    expect(l.boundsForScreenPos(t, {row: 3, column: 1})).equals(rect(padl+w*1,padt+3*h,w,h), "wrapped: pixel pos => text pos 4");
+    expect(l.boundsForScreenPos(t, {row: 0, column: 4})).equals(rect(padl+w*4,padt+0,0,h), "wrapped: pixel pos => text pos 5");
 
     expect(l.docToScreenPos(t, {row: 0, column: 4})).deep.equals({row: 1, column: 0}, "doc => screen pos 1");
     expect(l.docToScreenPos(t, {row: 0, column: 5})).deep.equals({row: 1, column: 1}, "doc => screen pos 2");

--- a/tests/text/rendering-test.js
+++ b/tests/text/rendering-test.js
@@ -24,12 +24,14 @@ const defaultStyle = {
   fixedCharacterSpacing: false
 }
 
+var padding = Rectangle.inset(3);
+
 function text(string, props) {
   return new Text({
     name: "text",
     textString: string,
     extent: pt(100,100),
-    padding: Rectangle.inset(3),
+    padding,
     fontMetric,
     ...defaultStyle,
     ...props
@@ -148,6 +150,31 @@ describe("text rendering", () => {
   
       expect(strings).equals(["h", "e", "l", "l", "o"]);
     });
+  });
+
+  describe("visible line detection", () => {
+
+    it("determines last and first full visible line based on padding and scroll", () => {
+      var {width: w, height: h} = fontMetric;
+      Object.assign(sut, {
+        textString: "111111\n222222\n333333\n444444\n555555",
+        padding, borderWidth: 0, fill: Color.lightGray,
+        lineWrapping: false, clipMode: "auto",
+        extent: pt(4*w+padding.left() + padding.right(), 3*h+padding.top()+padding.bottom())
+      });
+
+      var l = sut.textLayout;
+      sut.render(sut.env.renderer);
+      expect(l.firstFullVisibleLine(sut)).equals(0);
+      expect(l.lastFullVisibleLine(sut)).equals(2);
+
+      sut.scroll = sut.scroll.addXY(0, padding.top()+h);
+      sut.render(sut.env.renderer);
+
+      expect(l.firstFullVisibleLine(sut)).equals(1);
+      expect(l.lastFullVisibleLine(sut)).equals(3);
+    });
+
   });
 
 });

--- a/tests/text/selection-test.js
+++ b/tests/text/selection-test.js
@@ -258,42 +258,4 @@ describe("multi select", () => {
 
   });
 
-  describe("selection changes", () => {
-
-    it("go up and down with wrapped lines", () => {
-
-      var {width: charWidth,height: charHeight} = t.textLayout.fontMetric
-      Object.assign(t, {
-        textString: "a\ncdefg\n",
-        width: 3*charWidth,
-        lineWrapping: true,
-        clipMode: "hidden"
-      });
-
-      t.cursorPosition = {column: 5,row: 1};
-      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "before 1");
-
-      t.selection.goUp(1, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 1, column: 2}, "up wrapped line 1");
-      expect(t.cursorPosition).deep.equals({row: 1, column: 2}, "up wrapped line 2");
-
-      t.selection.goUp(1, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 0, column: 1}, "upped simple line ");
-
-      t.selection.goDown(3, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 3, column: 0}, "down into wrapped");
-
-      t.selection.goUp(1, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "up again from empty line");
-
-      t.cursorPosition = {row: 3, column: 0}
-      t.selection.goUp(1, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 0}, "up from empty line with goal column set to it");
-
-      t.cursorScreenPosition = {row: 2, column: 1}
-      t.selection.goUp(1, true);
-      expect(t.cursorScreenPosition).deep.equals({row: 1, column: 1}, "up from wrapped line with goal column set to it");
-    })
-
-  })
 });

--- a/tests/text/selection-test.js
+++ b/tests/text/selection-test.js
@@ -256,5 +256,44 @@ describe("multi select", () => {
       expect(t.selection.ranges).to.have.length(1);
     });
 
+  });
+
+  describe("selection changes", () => {
+
+    it("go up and down with wrapped lines", () => {
+
+      var {width: charWidth,height: charHeight} = t.textLayout.fontMetric
+      Object.assign(t, {
+        textString: "a\ncdefg\n",
+        width: 3*charWidth,
+        lineWrapping: true,
+        clipMode: "hidden"
+      });
+
+      t.cursorPosition = {column: 5,row: 1};
+      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "before 1");
+
+      t.selection.goUp(1, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 1, column: 2}, "up wrapped line 1");
+      expect(t.cursorPosition).deep.equals({row: 1, column: 2}, "up wrapped line 2");
+
+      t.selection.goUp(1, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 0, column: 1}, "upped simple line ");
+
+      t.selection.goDown(3, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 3, column: 0}, "down into wrapped");
+
+      t.selection.goUp(1, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 2}, "up again from empty line");
+
+      t.cursorPosition = {row: 3, column: 0}
+      t.selection.goUp(1, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 2, column: 0}, "up from empty line with goal column set to it");
+
+      t.cursorScreenPosition = {row: 2, column: 1}
+      t.selection.goUp(1, true);
+      expect(t.cursorScreenPosition).deep.equals({row: 1, column: 1}, "up from wrapped line with goal column set to it");
+    })
+
   })
 });

--- a/tests/text/selection-test.js
+++ b/tests/text/selection-test.js
@@ -236,7 +236,7 @@ describe("multi select", () => {
   });
 
   describe("range merging", () => {
-  
+
     it("same empty range", function() {
       t.textString = "Hello\nWorld";
       t.selection.addRange(range(0,4,0,4));

--- a/text/commands.js
+++ b/text/commands.js
@@ -262,7 +262,7 @@ var commands = [
     exec: function(morph) {
       morph.activeMark ?
         morph.selection.selectUp(1) :
-        morph.selection.goUp();
+        morph.selection.goUp(1, true/*use screen position*/);
       return true;
     }
   },
@@ -272,7 +272,7 @@ var commands = [
     exec: function(morph) {
       morph.activeMark ?
         morph.selection.selectDown(1) :
-        morph.selection.goDown(1);
+        morph.selection.goDown(1, true/*use screen position*/);
       return true;
     }
   },
@@ -289,12 +289,12 @@ var commands = [
 
   {
     name: "select up",
-    exec: function(morph) { morph.selection.selectUp(1); return true; }
+    exec: function(morph) { morph.selection.selectUp(1, true/*use screen position*/); return true; }
   },
 
   {
     name: "select down",
-    exec: function(morph) { morph.selection.selectDown(1); return true; }
+    exec: function(morph) { morph.selection.selectDown(1, true/*use screen position*/); return true; }
   },
 
   {
@@ -314,7 +314,7 @@ var commands = [
       var select = opts.select || !!morph.activeMark,
           sel = morph.selection,
           cursor = sel.lead,
-          line = morph.lineRange(cursor.row, true);
+          line = morph.screenLineRange(cursor, true);
       sel.lead = eqPosition(cursor, line.start) ? {column: 0, row: cursor.row} : line.start;
       !select && (sel.anchor = sel.lead);
       return true;
@@ -327,7 +327,7 @@ var commands = [
       var select = opts.select || !!morph.activeMark,
           sel = morph.selection,
           cursor = sel.lead,
-          line = morph.lineRange(cursor.row, true);
+          line = morph.screenLineRange(cursor, true);
       sel.lead = line.end;
       !select && (sel.anchor = sel.lead);
       return true;
@@ -1332,9 +1332,11 @@ var multiSelectCommands = [
     name: "[multi select] add cursor above",
     multiSelectAction: "single",
     exec: morph => {
-      var {row, column} = morph.selection.start;
-      if (row > 0)
-        morph.selection.addRange({start: {row: row-1, column}, end: {row: row-1, column}})
+      var start = morph.selection.start;      
+      if (start.row > 0) {
+        var pos = morph.getPositionAboveOrBelow(1, start, true)
+        morph.selection.addRange({start: pos, end: pos})
+      }
       return true;
     }
   },

--- a/text/commands.js
+++ b/text/commands.js
@@ -393,31 +393,11 @@ var commands = [
   },
 
   {
-    name: 'move cursor to screen top in 1/3 steps',
-    readOnly: true,
-    exec: function(morph) {
-      var select = !!morph.activeMark,
-          currentPos = morph.cursorPosition,
-          firstRow = morph.textLayout.firstFullVisibleLine(morph),
-          lastRow = morph.textLayout.lastFullVisibleLine(morph),
-          middleRow = firstRow+Math.floor((lastRow - firstRow)/2),
-          newPos = currentPos;
-      if (currentPos.row <= firstRow) return true;
-      if (currentPos.row <= middleRow) newPos.row = firstRow;
-      else if (currentPos.row <= lastRow) newPos.row = middleRow;
-      else newPos.row = lastRow;
-      morph.selection.lead = newPos;
-      if (!select) morph.selection.anchor = newPos;
-      return true;
-    }
- },
-
- {
     name: 'move cursor to screen bottom in 1/3 steps',
     readOnly: true,
     exec: function(morph) {
       var select = !!morph.activeMark,
-          currentPos = morph.cursorPosition,
+          currentPos = morph.lineWrapping ? morph.cursorScreenPosition : morph.cursorPosition,
           firstRow = morph.textLayout.firstFullVisibleLine(morph),
           lastRow = morph.textLayout.lastFullVisibleLine(morph),
           middleRow = firstRow+Math.floor((lastRow - firstRow)/2),
@@ -426,8 +406,8 @@ var commands = [
       else if (currentPos.row < middleRow) newPos.row = middleRow;
       else if (currentPos.row < lastRow) newPos.row = lastRow;
       else return true;
-      morph.selection.lead = newPos;
-      if (!select) morph.selection.anchor = newPos;
+      morph.selection.lead = morph.lineWrapping ? morph.toDocumentPosition(newPos) : newPos;
+      if (!select) morph.selection.anchor = morph.selection.lead;
       return true;
     }
   },
@@ -437,37 +417,17 @@ var commands = [
     readOnly: true,
     exec: function(morph) {
       var select = !!morph.activeMark,
-          currentPos = morph.cursorPosition,
-          firstRow = morph.textLayout.firstFullyVisibleLine,
-          lastRow = morph.textLayout.lastFullyVisibleLine,
+          currentPos = morph.lineWrapping ? morph.cursorScreenPosition : morph.cursorPosition,
+          firstRow = morph.textLayout.firstFullVisibleLine(morph),
+          lastRow = morph.textLayout.lastFullVisibleLine(morph),
           middleRow = firstRow+Math.floor((lastRow - firstRow)/2),
           newPos = currentPos;
       if (currentPos.row <= firstRow) return true;
       if (currentPos.row <= middleRow) newPos.row = firstRow;
       else if (currentPos.row <= lastRow) newPos.row = middleRow;
       else newPos.row = lastRow;
-      morph.selection.lead = newPos;
-      if (!select) morph.selection.anchor = newPos;
-      return true;
-    }
- },
-
- {
-    name: 'move cursor to screen bottom in 1/3 steps',
-    readOnly: true,
-    exec: function(morph) {
-      var select = !!morph.activeMark,
-          currentPos = morph.cursorPosition,
-          firstRow = morph.textLayout.firstFullyVisibleLine,
-          lastRow = morph.textLayout.lastFullyVisibleLine,
-          middleRow = firstRow+Math.floor((lastRow - firstRow)/2),
-          newPos = currentPos;
-      if (currentPos.row < firstRow) newPos.row = firstRow;
-      else if (currentPos.row < middleRow) newPos.row = middleRow;
-      else if (currentPos.row < lastRow) newPos.row = lastRow;
-      else return true;
-      morph.selection.lead = newPos;
-      if (!select) morph.selection.anchor = newPos;
+      morph.selection.lead = morph.lineWrapping ? morph.toDocumentPosition(newPos) : newPos;
+      if (!select) morph.selection.anchor = morph.selection.lead;
       return true;
     }
   },

--- a/text/commands.js
+++ b/text/commands.js
@@ -940,6 +940,16 @@ var commands = [
   },
 
   {
+    name: "toggle line wrapping",
+    scrollCursorIntoView: false,
+    multiSelectAction: "single",
+    exec: function(morph) {
+      morph.keepPosAtSameScrollOffsetWhile(() => morph.lineWrapping = !morph.lineWrapping);
+      return true;
+    }
+  },
+
+  {
     name: "increase font size",
     scrollCursorIntoView: false,
     exec: function(morph) { morph.keepPosAtSameScrollOffsetWhile(() => morph.fontSize++); return true; }

--- a/text/layout.js
+++ b/text/layout.js
@@ -24,6 +24,48 @@ function styleFromTextAttributes(textAttributes) {
   return s;
 }
 
+function chunksFrom(textOfLine, fontMetric, textAttributesOfLine) {
+  let chunks = [];
+  for (var i = 0; i < textAttributesOfLine.length; i += 3) {
+    var startCol = textAttributesOfLine[i],
+        endCol = textAttributesOfLine[i+1],
+        attributes = textAttributesOfLine[i+2];
+    chunks.push(new TextChunk(textOfLine.slice(startCol, endCol), fontMetric, attributes));
+  }
+  return chunks;
+}
+
+function updateChunks(oldChunks, newChunks) {
+  // compares oldChunks with newChunks and modifies(!) oldChunks so that the
+  // oldChunks list gets patched with changed or new chunks
+  // returns true if changes occurred, false otherwise
+  if (!oldChunks.length && newChunks.length) {
+    oldChunks.push(...newChunks);
+    return true;
+  }
+
+  let oldChunkCount = oldChunks.length,
+      newChunkCount = newChunks.length,
+      changed = false;
+
+  for (let i = 0; i < newChunks.length; i++) {
+    let oldChunk = oldChunks[i],
+        newChunk = newChunks[i],
+        { text: newText, fontMetric: newFontMetric, textAttributes: newTextAttributes } = newChunk;
+    if (!oldChunk || !oldChunk.compatibleWith(newText, newFontMetric, newTextAttributes)) {
+      oldChunks[i] = newChunk;
+      changed = true;
+    }
+  }
+
+  if (newChunkCount < oldChunkCount) {
+    oldChunks.splice(newChunkCount, oldChunkCount - newChunkCount);
+    changed = true;
+  }
+
+  return changed;
+}
+
 class TextChunk {
 
   constructor(text, fontMetric, textAttributes) {
@@ -44,6 +86,7 @@ class TextChunk {
   }
 
   compatibleWith(text2, fontMetric2, textAttributes2) {
+    // return false;
     var {text, fontMetric, style} = this;
     return text === text2
         && fontMetric === fontMetric2
@@ -69,12 +112,18 @@ class TextChunk {
   }
 
   computeBounds() {
-    let width = 0, height = 0;
-
-    this.charBounds.map(char => {
-      width += char.width;
-      height = Math.max(height, char.height);
-    });
+    let width = 0, height = 0,
+        bounds = this.charBounds,
+        nBounds = bounds.length;
+    if (nBounds === 0) {
+      height = this.fontMetric.defaultLineHeight(this.style);
+    } else {
+      for (var i = 0; i < bounds.length; i++) {
+        var char = bounds[i];
+        width += char.width;
+        height = Math.max(height, char.height);
+      }
+    }
     this._height = height;
     this._width = width;
     return this;
@@ -86,59 +135,58 @@ class TextChunk {
       [] : fontMetric.charBoundsFor(style, text);
   }
 
-  splitToNotBeWiderAs(maxWidth) {
-    if (this.width <= maxWidth) return [this];
+  splitAt(splitWidth) {
+    var width = this.width;
+    if (splitWidth <= 0 || width < splitWidth) return [this];
 
-    var {charBounds, _style, _height} = this,
-        chunks = [];
+    var {_charBounds, _style, _height, text, fontMetric, textAttributes} = this;
 
-    var current = {from: 0, width: 0};
-    var lastSplitX = 0;
+    if (!_charBounds.length) return [this];
 
-    for (var i = 0; i < charBounds.length; i++) {
-      var {x,width} = charBounds[i];
-      if (current.width === 0
-       || x-lastSplitX + current.width + width <= maxWidth) { current.width += width; continue; }
+    // if (splitWidth < _charBounds[0].width) return [null, this];
 
-      chunks.push(Object.assign(new TextChunk(this.text.slice(current.from, i), this.fontMetric, this.textAttributes), {
-        _style, _width: current.width, _height, _charBounds: charBounds.slice(current.from, i)}));
+    for (let i = 1/*min 1 char*/; i < _charBounds.length; i++) {
+      let {x, width: w} = _charBounds[i],
+          currentWidth = x+w;
+      if (currentWidth <= splitWidth) continue;
+      let left = Object.assign(
+                  new TextChunk(text.slice(0, i), fontMetric, textAttributes),
+                  {_style, _width: x, _height, _charBounds: _charBounds.slice(0, i)}),
+          nextWidth = 0,
+          charBoundsSplitted = _charBounds.slice(i).map(ea => {
+            nextWidth += ea.width; return {...ea, x: ea.x-x} }),
+          right = Object.assign(
+            new TextChunk(text.slice(i), fontMetric, textAttributes),
+            {_style, _width: nextWidth, _height, _charBounds: charBoundsSplitted});
 
-      current.width = width;
-      current.from = i;
-      lastSplitX = x + width;
+      return [left, right]
+
     }
 
-    if (current.width) {
-      chunks.push(Object.assign(new TextChunk(this.text.slice(current.from, i), this.fontMetric, this.textAttributes), {
-        _style, _width: current.width, _height, _charBounds: charBounds.slice(current.from, i)}));
-    }
-// console.log(`${current.from}, ${i}`)
-    
-    return chunks;
+    console.warn("Chunk split failed! Reached max width but found no char bounds to split");
+    return [this];
   }
+
 }
 
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 class TextLayoutLine {
 
-  static chunksFrom(text, fontMetric, textAttributesOfLine) {
-    let chunks = [];
-    for (var i = 0; i < textAttributesOfLine.length; i += 3) {
-      var startCol = textAttributesOfLine[i],
-          endCol = textAttributesOfLine[i+1],
-          attributes = textAttributesOfLine[i+2];
-      chunks.push(new TextChunk(text.slice(startCol, endCol), fontMetric, attributes));
-    }
-    return chunks;
-  }
-
-  constructor(text, fontMetric, textAttributesOfLine) {
-    this.updateIfNecessary(text, fontMetric, textAttributesOfLine);
+  constructor(chunks = []) {
+    this.chunks = chunks;
+    this.resetCache();
   }
 
   resetCache() {
     this.rendered = this._charBounds = this._height = this._width = undefined;
+  }
+
+  get length() {
+    var l = 0;
+    for (let i = 0; i < this.chunks.length; i++)
+      l += this.chunks[i].length
+    return l;
   }
 
   get height() {
@@ -153,41 +201,18 @@ class TextLayoutLine {
 
   computeBounds() {
     this._width = this._height = 0;
-    this.chunks.map(chunk => {
+    for (let i = 0; i < this.chunks.length; i++) {
+      var chunk = this.chunks[i];
       this._width += chunk.width;
       this._height = Math.max(this._height, chunk.height);
-    });
+    }
     return this;
   }
 
-  updateIfNecessary(text, fontMetric, textAttributes) {
-    let newChunks = this.constructor.chunksFrom(text, fontMetric, textAttributes),
-        {chunks: oldChunks} = this;
-    if (!oldChunks) {
-      this.chunks = newChunks
-      return;
-    }
-
-    let oldChunkCount = oldChunks.length,
-        newChunkCount = newChunks.length,
-        shouldReset = false;
-
-    for (let i = 0; i < newChunks.length; i++) {
-      let oldChunk = oldChunks[i],
-          newChunk = newChunks[i],
-          { text: newText, fontMetric: newFontMetric, textAttributes: newTextAttributes } = newChunk;
-      if (!oldChunk || !oldChunk.compatibleWith(newText, newFontMetric, newTextAttributes)) {
-        this.chunks[i] = newChunk;
-        shouldReset = true;
-      }
-    }
-
-    if (newChunkCount < oldChunkCount) {
-      this.chunks.splice(newChunkCount, oldChunkCount - newChunkCount);
-      shouldReset = true;
-    }
-
-    if (shouldReset) this.resetCache();
+  updateIfNecessary(newChunks) {
+    var changed = updateChunks(this.chunks, newChunks);
+    changed && this.resetCache();
+    return changed;
   }
 
   boundsFor(column) {
@@ -197,24 +222,32 @@ class TextLayoutLine {
         || {x: 0, y: 0, width: 0, height: 0};
   }
 
-  columnForXOffset(xInPixels) {
+  rowColumnOffsetForPixelPos(xInPixels, yInPixels) {
     let {charBounds} = this,
         length = charBounds.length,
         first = charBounds[0],
-        last = charBounds[length-1];
+        last = charBounds[length-1],
+        result = {row: 0, column: 0};
 
     // everything to the left of the first char + half its width is col 0
-    if (!length || xInPixels <= first.x+Math.round(first.width/2)) return 0;
+    if (!length || xInPixels <= first.x+Math.round(first.width/2)) return result;
 
     // everything to the right of the last char + half its width is last col
-    if (xInPixels > last.x+Math.round(last.width/2)) return length-1;
+    if (xInPixels > last.x+Math.round(last.width/2)) {
+      result.column = length-1;
+      return result;
+    }
 
     // find col so that x between right side of char[col-1] and left side of char[col]
     for (var i = length-2; i >= 0; i--) {
       let {x, width} = charBounds[i];
-      if (xInPixels >= x + Math.round(width/2)) return i+1;
+      if (xInPixels >= x + Math.round(width/2)) {
+        result.column = i+1;
+        return result;
+      }
     }
-    return 0;
+
+    return result;
   }
 
   get charBounds() {
@@ -244,50 +277,163 @@ class TextLayoutLine {
     this._charBounds.push({x: prefixWidth, y: 0, width: 0, height: lineHeight});
   }
 
+
 }
 
-class TextLayoutWrappableLine extends TextLayoutLine {
 
-  updateIfNecessary(text, fontMetric, textAttributes) {
-    if (!this.wrappedLines) this.wrappedLines = [];
+class WrappedTextLayoutLine {
 
-    var newVisibleBounds = text.innerBounds(),
-        oldVisibleBounds = this.visibleBounds;
+  constructor() {
+    this.chunks = [];
+    this.wrappedLines = [];
+    this._wrapAt = Infinity;
+    this.resetCache();
+  }
 
-    if (!oldVisibleBounds || oldVisibleBounds.equals(newVisibleBounds)) {
-      this.chunks.length = 0;
+  resetCache() {
+    this._charBounds = this._height = this._width = undefined;
+  }
+
+  get length() {
+    var l = 0;
+    for (let i = 0; i < this.wrappedLines.length; i++)
+      l += this.wrappedLines[i].length
+    return l;
+  }
+
+  get wrapAt() { return this._wrapAt; }
+  set wrapAt(x) {
+    var changed = this._wrapAt !== x;
+    this._wrapAt = x;
+    changed && this.resetCache();
+  }
+
+  get height() {
+    if (this._height === undefined) this.computeBounds();
+    return this._height;
+  }
+
+  get width() {
+    if (this._width === undefined) this.computeBounds();
+    return this._width;
+  }
+
+  computeBounds() {
+    this._width = this._height = 0;
+    for (let i = 0; i < this.wrappedLines.length; i++) {
+      let l = this.wrappedLines[i];
+      this._width = Math.max(l.width, this._width);
+      this._height += l.height;
     }
+    return this;
+  }
 
-    let newChunks = this.constructor.chunksFrom(text, fontMetric, textAttributes),
-        {chunks: oldChunks} = this;
-    if (!oldChunks) {
-      this.chunks = newChunks
-      return;
-    }
+  updateIfNecessary(newcChunks, wrapAt) {
+    let chunks = this.chunks,
+        changed = updateChunks(chunks, newcChunks) || this.wrapAt !== wrapAt;
 
-    let oldChunkCount = oldChunks.length,
-        newChunkCount = newChunks.length,
-        shouldReset = false;
+    if (!changed) return false;
 
-    for (let i = 0; i < newChunks.length; i++) {
-      let oldChunk = oldChunks[i],
-          newChunk = newChunks[i],
-          { text: newText, fontMetric: newFontMetric, textAttributes: newTextAttributes } = newChunk;
-      if (!oldChunk || !oldChunk.compatibleWith(newText, newFontMetric, newTextAttributes)) {
-        this.chunks[i] = newChunk;
-        shouldReset = true;
+    this.wrapAt = wrapAt;
+
+    var chunksByLine = [[]],
+        currentLineChunks = chunksByLine[0],
+        x = 0;
+
+    for (let i = 0; i < chunks.length; i++) {
+
+
+      // let nextChunk = chunks.shift(),
+      let nextChunk = chunks[i],
+          nextW = nextChunk.width,
+          nextX = x + nextW;
+
+      if (x + nextW <= wrapAt) { x += nextW; currentLineChunks.push(nextChunk); continue; }
+      // let localWraptAt = wrapAt-x;
+
+      while (true) {
+        let [split1, split2] = nextChunk.splitAt(wrapAt-x);
+        if (split1) {
+          x += split1.width;
+          currentLineChunks.push(split1);
+        }
+        if (!split2) break;
+
+        chunksByLine.push(currentLineChunks = []);
+        x = 0;
+        nextChunk = split2;
       }
+
     }
 
-    if (newChunkCount < oldChunkCount) {
-      this.chunks.splice(newChunkCount, oldChunkCount - newChunkCount);
-      shouldReset = true;
+    let nLines = chunksByLine.length;
+
+    for (let i = 0; i < nLines; i++) {
+      let chunks = chunksByLine[i],
+          line = this.wrappedLines[i] || (this.wrappedLines[i] =  new TextLayoutLine())
+      line.updateIfNecessary(chunks);
     }
 
-    if (shouldReset) this.resetCache();
+    if (nLines !== this.wrappedLines.length) {
+      this.wrappedLines.splice(nLines, this.wrappedLines.length - nLines);
+    }
+
+    this.resetCache();
+    return true;
+  }
+
+  boundsFor(column) {
+    var charBounds = this.charBounds;
+    return charBounds[column]
+        || charBounds[charBounds.length-1]
+        || {x: 0, y: 0, width: 0, height: 0};
+  }
+
+  rowColumnOffsetForPixelPos(xInPixels, yInPixels) {
+    // look for the wrapped line and offset row accordingly,
+    // use rowColumnOffsetForPixelPos of simple line for column
+    var line, currentHeight = 0, lines = this.wrappedLines;
+    for (var i = 0; i < lines.length; i++) {
+      line = lines[i];
+      currentHeight += line.height;
+      if (currentHeight > yInPixels) break;
+    }
+    return {
+      column: line.rowColumnOffsetForPixelPos(xInPixels, currentHeight - yInPixels).column,
+      row: i
+    }
+  }
+
+  get charBounds() {
+    if (this._charBounds === undefined) this.computeCharBounds();
+    return this._charBounds;
+  }
+
+  computeCharBounds() {
+    let currentX = 0, currentY = 0,
+        { wrappedLines } = this;
+
+    this._charBounds = [];
+
+    for (let i = 0; i < wrappedLines.length; i++) {
+
+      let { charBounds, height: lineHeight } = wrappedLines[i];
+
+      for (let j = 0; j < charBounds.length; j++) {
+        let bounds = charBounds[j],
+            {x, y, width, height} = bounds;
+
+        // add its bounding box
+        this._charBounds.push({x: x + currentX, y: y+currentY, width, height});
+      }
+
+      currentY += lineHeight
+    }
+
   }
 
 }
+
 
 
 export default class TextLayout {
@@ -305,6 +451,20 @@ export default class TextLayout {
     this.lastVisibleLine = undefined;
   }
 
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // accessing
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+  wrappedLines(morph) {
+    this.updateFromMorphIfNecessary(morph);
+    if (!this.lineWrapping)
+      return this.lines;
+    var wrappedLines = [], lines = this.lines;
+    for (let i = 0; i < lines.length; i++)
+      wrappedLines.push(...lines[i].wrappedLines);
+    return wrappedLines;
+  }
+
   firstFullVisibleLine(morph) {
     var bounds = this.boundsFor(morph, {row: this.firstVisibleLine, column: 0});
     return this.firstVisibleLine + (bounds.top() < morph.scroll.y ? 1 : 0);
@@ -319,6 +479,10 @@ export default class TextLayout {
     return this.fontMetric.sizeFor(morph.fontFamily, morph.fontSize, "X");
   }
 
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // updating
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
   shiftLinesIfNeeded(morph, {start, end}, changeType) {
     var nRows = end.row - start.row;
     if (nRows === 0) return;
@@ -331,24 +495,30 @@ export default class TextLayout {
   updateFromMorphIfNecessary(morph) {
     if (this.layoutComputed) return false;
 
-// TODO: specify which lines have changed!
+    // TODO: specify which lines have changed!
 
     let doc = morph.document,
+        lineWrappingBefore = this.lineWrapping,
+        lineWrapping = this.lineWrapping = morph.lineWrapping,
+        Line = lineWrapping ? WrappedTextLayoutLine : TextLayoutLine,
+        wrapAt = lineWrapping && morph.fixedWidth ? morph.width : Infinity,
         fontMetric = this.fontMetric,
-        lines = doc.lines,
-        nRows = lines.length,
+        docLines = doc.lines,
+        nRows = docLines.length,
         textAttributesChunked = doc.textAttributesChunked(0, nRows-1),
-        Line = this.lineWrapping ? TextLayoutWrappableLine : TextLayoutLine,
         morphBounds = morph.innerBounds();
+
+    // need different keinds of lines, so reset
+    if (lineWrapping !== lineWrappingBefore) this.lines = [];
 
     for (let row = 0; row < nRows; row++) {
       let textAttributesOfLine = textAttributesChunked[row],
-          text = lines[row],
-          line = this.lines[row];
-      if (!line)
-        this.lines[row] = new Line(text, fontMetric, textAttributesOfLine);
-      else
-        line.updateIfNecessary(text, fontMetric, textAttributesOfLine);
+          text = docLines[row],
+          line = this.lines[row],
+          chunksOfLine = chunksFrom(text, fontMetric, textAttributesOfLine);
+
+      if (!line) line = this.lines[row] = new Line();
+      line.updateIfNecessary(chunksOfLine, wrapAt);
     }
     this.lines.splice(nRows, this.lines.length - nRows);
 
@@ -356,8 +526,13 @@ export default class TextLayout {
     return true;
   }
 
-  pixelPositionFor(morph, pos) {
-    var { x, y } = this.boundsFor(morph, pos);
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+  // position access and conversion, including
+  // pixel pos <=> doc pos <=> screen pos
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+  pixelPositionFor(morph, docPos) {
+    var { x, y } = this.boundsFor(morph, docPos);
     return pt(x, y);
   }
 
@@ -366,42 +541,24 @@ export default class TextLayout {
     return this.pixelPositionFor(morph, pos);
   }
 
-  textPositionFor(morph, point) {
-    this.updateFromMorphIfNecessary(morph);
-    var {lines} = this;
-    if (!lines.length) return {row: 0, column: 0};
-
-    let {x,y: remainingHeight} = point, line, row;
-    if (remainingHeight < 0) remainingHeight = 0;
-    for (row = 0; row < lines.length; row++) {
-      line = lines[row];
-      if (remainingHeight < line.height) break;
-      remainingHeight -= line.height;
-    }
-
-    return {row, column: line.columnForXOffset(x)};
+  pixelPositionForScreenPos(morph, pos) {
+    var { x, y } = this.boundsForScreenPos(morph, pos);
+    return pt(x, y);
   }
 
-  textIndexFor(morph, point) {
-    var pos = this.textPositionFor(morph, point);
-    return morph.document.positionToIndex(pos);
+  boundsFor(morph, docPos) {
+    return this.boundsForScreenPos(morph, this.docToScreenPos(morph, docPos));
   }
 
-  textBounds(morph) {
+  boundsForIndex(morph, index) {
     this.updateFromMorphIfNecessary(morph);
-    let textWidth = 0, textHeight = 0;
-    for (let row = 0; row < this.lines.length; row++) {
-      var {width, height} = this.lines[row];
-      textWidth = Math.max(width, textWidth);
-      textHeight += height;
-    }
-    return new Rectangle(0,0, textWidth, textHeight);
+    var pos = morph.document.indexToPosition(index);
+    return this.boundsFor(morph, pos);
   }
 
-
-  boundsFor(morph, {row, column}) {
+  boundsForScreenPos(morph, {row, column}) {
     this.updateFromMorphIfNecessary(morph);
-    let {lines} = this,
+    let lines = this.wrappedLines(morph),
         maxLength = lines.length-1,
         safeRow = Math.max(0, Math.min(maxLength, row)),
         line = lines[safeRow];
@@ -414,9 +571,102 @@ export default class TextLayout {
     return new Rectangle(x, y, width, height);
   }
 
-  boundsForIndex(morph, index) {
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+  screenPositionFor(morph, point) {
     this.updateFromMorphIfNecessary(morph);
-    var pos = morph.document.indexToPosition(index);
-    return this.boundsFor(morph, pos);
+    var lines = this.wrappedLines(morph);
+    if (!lines.length) return {row: 0, column: 0};
+
+    let {x,y: remainingHeight} = point, line, row = 0;
+    if (remainingHeight < 0) remainingHeight = 0;
+
+    for (; row < lines.length; row++) {
+      line = lines[row];
+      if (remainingHeight < line.height) break;
+      remainingHeight -= line.height;
+    }
+    row = Math.min(row, lines.length-1)
+
+    var {row: rowOffset, column: columnOffset} =
+      line.rowColumnOffsetForPixelPos(x, remainingHeight);
+
+    return {row: row+rowOffset, column: columnOffset};
   }
+
+  textIndexFor(morph, point) {
+    var pos = this.textPositionFor(morph, point);
+    return morph.document.positionToIndex(pos);
+  }
+
+  textBounds(morph) {
+    this.updateFromMorphIfNecessary(morph);
+    let textWidth = 0, textHeight = 0,
+        lines = this.wrappedLines(morph);
+    for (let row = 0; row < lines.length; row++) {
+      var {width, height} = lines[row];
+      textWidth = Math.max(width, textWidth);
+      textHeight += height;
+    }
+    return new Rectangle(0,0, textWidth, textHeight);
+  }
+
+  // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+  docToScreenPos(morph, {row, column}) {
+    if (!this.lineWrapping) return {row, column};
+    this.updateFromMorphIfNecessary(morph);
+    var screenRow = Math.max(0, row),
+        line = this.lines[row];
+    if (!line) line = this.lines[row = this.lines.length-1];
+    if (!line) return {row: 0, column: 0};
+
+    var screenRows = 0;
+    for (let j = 0; j < row; j++)
+      screenRows += this.lines[j].wrappedLines.length;
+
+    var columnLeft = column, nChars;
+    for (var i = 0; i < line.wrappedLines.length; i++) {
+      nChars = line.wrappedLines[i].length;
+      if (columnLeft < nChars)
+        return {row: screenRows+i, column: columnLeft}
+      columnLeft -= nChars;
+    }
+    return {row: screenRows+i-1, column: nChars}
+  }
+
+  screenToDocPos(morph, {row, column}) {
+    if (!this.lineWrapping) {
+      row = Math.max(0, Math.min(row, this.lines.length-1));
+      column = Math.max(0, Math.min(column, this.lines.length));
+      return {row, column};
+    }
+
+    this.updateFromMorphIfNecessary(morph);
+
+    let wrappedLines = [], lines = this.lines,
+        targetLine,
+        screenRow = 0,
+        docCol, docRow, found = false;
+
+    for (docRow = 0; docRow < lines.length; docRow++) {
+      docCol = 0;
+      let wrappedLines = lines[docRow].wrappedLines;
+      for (let i = 0; i < wrappedLines.length; i++, screenRow++) {
+        if (screenRow === row) {
+          column = Math.min(column, wrappedLines[i].length);
+          docCol += column;
+          found = true;
+          break;
+        }
+        docCol += wrappedLines[i].length;
+      }
+      if (found) break;
+    }
+
+    return found ?
+      {row: docRow, column: docCol} :
+      {row: docRow-1, column: lines[docRow-1].length};
+  }
+
 }

--- a/text/layout.js
+++ b/text/layout.js
@@ -82,8 +82,8 @@ class TextChunk {
 
   computeCharBounds() {
     let {text, fontMetric, style} = this;
-    text += newline;
-    this._charBounds = fontMetric.charBoundsFor(style, text);
+    this._charBounds = text.length === 0 ?
+      [] : fontMetric.charBoundsFor(style, text);
   }
 
   splitToNotBeWiderAs(maxWidth) {
@@ -224,19 +224,24 @@ class TextLayoutLine {
 
   computeCharBounds() {
     let prefixWidth = 0,
-        {chunks, height: lineHeight } = this,
+        { chunks, height: lineHeight } = this,
         nChunks = chunks.length;
     this._charBounds = [];
-    for (let i = 0; i < nChunks; i++) {
-      let chunk = chunks[i],
-          { charBounds, width, height } = chunk,
-          offsetCharBounds =
-            charBounds.map(bounds => { let {x, y, width} = bounds;
-                                       return {x: x + prefixWidth, y, width, height: lineHeight}});
-        prefixWidth += width;
-        if (i < nChunks - 1) offsetCharBounds.splice(-1, 1);
-        offsetCharBounds.map(ea => this._charBounds.push(ea));
+
+    for (var i = 0; i < nChunks; i++) {
+      let { charBounds, width, height } = chunks[i];
+
+      for (let j = 0; j < charBounds.length; j++) {
+        let bounds = charBounds[j],
+            {x, y, width} = bounds;
+        this._charBounds.push({x: x + prefixWidth, y, width, height: lineHeight});
+      }
+
+      prefixWidth += width;
     }
+
+    // "newline"
+    this._charBounds.push({x: prefixWidth, y: 0, width: 0, height: lineHeight});
   }
 
 }

--- a/text/morph.js
+++ b/text/morph.js
@@ -100,7 +100,10 @@ export class Text extends Morph {
   onChange(change) {
     var textChange = change.selector === "insertText"
                   || change.selector === "deleteText";
+
     if (textChange
+     || (change.prop === "extent" && this.lineWrapping && this.isClip())
+     || (change.prop === "lineWrapping" && this.isClip())
      || change.prop === "fixedWidth"
      || change.prop === "fixedHeight"
      || change.prop === "fontFamily"
@@ -110,8 +113,7 @@ export class Text extends Morph {
      || change.prop === "fontStyle"
      || change.prop === "textDecoration"
      || change.prop === "fixedCharacterSpacing"
-     || change.prop === "lineWrapping")
-       this.textLayout && (this.textLayout.layoutComputed = false);
+    ) this.textLayout && (this.textLayout.layoutComputed = false);
 
     super.onChange(change);
     textChange && signal(this, "textChange");

--- a/text/morph.js
+++ b/text/morph.js
@@ -704,6 +704,7 @@ export class Text extends Morph {
   getPositionAboveOrBelow(n = 1, pos = this.cursorPosition, useScreenPosition = false, goalColumn) {
     // n > 0 above, n < 0 below
 
+    if (n === 0) return pos;
 
     if (!useScreenPosition) {
       if (goalColumn === undefined) goalColumn = pos.column
@@ -756,7 +757,11 @@ export class Text extends Morph {
         column = nextRange.start.column + columnOffset;
     if (!nextRangeIsAtLineEnd && column >= nextRange.end.column) column--;
 
-    return {row: nextRange.end.row, column};
+    var newPos = {row: nextRange.end.row, column};
+
+    return Math.abs(n) > 1 ?
+      this.getPositionAboveOrBelow(n + (n > 1 ? -1 : 1), newPos, useScreenPosition, goalColumn) :
+      newPos
   }
 
   collapseSelection() {

--- a/text/morph.js
+++ b/text/morph.js
@@ -689,6 +689,8 @@ export class Text extends Morph {
   get cursorPosition() { return this.selection.lead; }
   set cursorPosition(p) { this.selection.range = {start: p, end: p}; }
   get documentEndPosition() { return this.document.endPosition; }
+  get cursorScreenPosition() { return this.toScreenPosition(this.cursorPosition); }
+  set cursorScreenPosition(p) { return this.cursorPosition = this.toDocumentPosition(p); }
 
   cursorUp(n = 1) { return this.selection.goUp(n); }
   cursorDown(n = 1) { return this.selection.goDown(n); }

--- a/text/morph.js
+++ b/text/morph.js
@@ -456,6 +456,21 @@ export class Text extends Morph {
     return new Range(range);
   }
 
+  rangesOfWrappedLine(row = this.cursorPosition.row) {
+    return this.textLayout.rangesOfWrappedLine(this, row);
+  }
+
+  screenLineRange(pos = this.cursorPosition, ignoreLeadingWhitespace = true) {
+    var ranges = this.textLayout.rangesOfWrappedLine(this, pos.row),
+        range = ranges.slice().reverse().find(({start, end}) => start.column <= pos.column),
+        content = this.textInRange(range),
+        leadingSpace = content.match(/^\s*/);
+    if (leadingSpace[0].length && ignoreLeadingWhitespace)
+      range.start.column += leadingSpace[0].length;
+    if (range !== arr.last(ranges)) range.end.column--;
+    return new Range(range);
+  }
+
   insertTextWithTextAttributes(text, attributes = [], pos) {
     if (!Array.isArray(attributes)) attributes = [attributes];
     var range = this.insertText(text, pos);

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -46,13 +46,15 @@ function renderSelectionLayer(textLayouter, morph, selection, diminished = false
 
   if (!selection) return [];
 
-  let {start, end, lead, cursorVisible} = selection,
+  var {start, end, lead, cursorVisible} = selection,
+      start               = textLayouter.docToScreenPos(morph, start),
+      end                 = textLayouter.docToScreenPos(morph, end),
       isReverse           = selection.isReverse(),
       {padding, document} = morph,
-      lines               = textLayouter.lines,
+      lines               = textLayouter.wrappedLines(morph),
       paddingOffset       = padding.topLeft(),
-      startPos            = textLayouter.pixelPositionFor(morph, start).addPt(paddingOffset),
-      endPos              = textLayouter.pixelPositionFor(morph, end).addPt(paddingOffset),
+      startPos            = textLayouter.pixelPositionForScreenPos(morph, start).addPt(paddingOffset),
+      endPos              = textLayouter.pixelPositionForScreenPos(morph, end).addPt(paddingOffset),
       cursorPos           = isReverse ? startPos : endPos,
       defaultHeight       = null,
       endLineHeight       = end.row in lines ?
@@ -124,7 +126,7 @@ function renderMarkerLayer(textLayouter, morph) {
 }
 
 function renderTextLayer(textLayouter, morph) {
-  let {lines} = textLayouter,
+  let lines = textLayouter.wrappedLines(morph),
       textWidth = 0, textHeight = 0,
       {padding, scroll, height} = morph,
       {y: visibleTop} = scroll.subPt(padding.topLeft()),
@@ -182,7 +184,7 @@ function renderTextLayer(textLayouter, morph) {
 }
 
 function renderDebugLayer(textLayouter, morph) {
-  let {lines} = textLayouter,
+  let lines = textLayouter.wrappedLines(morph),
       {y: visibleTop} = morph.scroll,
       visibleBottom = visibleTop + morph.height,
       {padding} = morph,

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -50,11 +50,10 @@ function renderSelectionLayer(textLayouter, morph, selection, diminished = false
       start               = textLayouter.docToScreenPos(morph, start),
       end                 = textLayouter.docToScreenPos(morph, end),
       isReverse           = selection.isReverse(),
-      {padding, document} = morph,
+      {document}          = morph,
       lines               = textLayouter.wrappedLines(morph),
-      paddingOffset       = padding.topLeft(),
-      startPos            = textLayouter.pixelPositionForScreenPos(morph, start).addPt(paddingOffset),
-      endPos              = textLayouter.pixelPositionForScreenPos(morph, end).addPt(paddingOffset),
+      startPos            = textLayouter.pixelPositionForScreenPos(morph, start),
+      endPos              = textLayouter.pixelPositionForScreenPos(morph, end),
       cursorPos           = isReverse ? startPos : endPos,
       defaultHeight       = null,
       endLineHeight       = end.row in lines ?
@@ -261,15 +260,14 @@ function cursor(pos, height, visible, diminished, width) {
 }
 
 function renderMarkerPart(textLayouter, morph, start, end, style) {
-  var padding = morph.padding,
-      {x,y} = textLayouter.boundsFor(morph, start),
+  var {x,y} = textLayouter.boundsFor(morph, start),
       {height, x: endX} = textLayouter.boundsFor(morph, end);
   return h("div.marker-layer-part", {
     style: {
       zIndex: -4,
       ...style,
       position: "absolute",
-      left: padding.left()+x + "px", top: padding.top()+y + "px",
+      left: x + "px", top: y + "px",
       height: height + "px",
       width: endX-x + "px"
     }

--- a/text/rendering.js
+++ b/text/rendering.js
@@ -2,10 +2,18 @@ import { defaultStyle, defaultAttributes } from "../rendering/morphic-default.js
 import { h } from "virtual-dom";
 import { pt } from "lively.graphics";
 
+export var defaultRenderer = {
+
+  renderMorph(renderer, morph) {
+    return renderMorph(renderer, morph);
+  }
+
+}
+
 export function renderMorph(renderer, morph) {
   var textLayout = morph.textLayout;
 
-  textLayout.updateFromDocumentIfNecessary(morph.document);
+  textLayout.updateFromMorphIfNecessary(morph);
 
   var cursorWidth = morph.fontSize <= 11 ? 2 : 3,
       selectionLayer = [];


### PR DESCRIPTION
ref #38 
## Todo
- [x] layout lines according to wrap width
- [x] fix optimizations (only recompute lines / chunks if necessary)
- [x] provide interface for screen and document coordinate systems
- [x] make renderer work with wrapped lines
- [x] text layout tests
- [x] rendering tests
- [x] fix text commands that should use screen positions instead of doc positions
  - [x] arrow up/down
  - [x] go to line start/end
  - ...
## Summary

This allows our text layouter to optionally wrap lines based on a `wrapAt` value that will usually be the text morph width.

![line-wrapping](https://cloud.githubusercontent.com/assets/467450/19018641/aa357264-881f-11e6-9317-7af91352113c.gif)
## Structure

If wrapping is disabled then the following structure is used to compute the layout and is what the renderer works with:

![image](https://cloud.githubusercontent.com/assets/467450/19018579/74e8b6aa-881c-11e6-88d1-b57d07120886.png)

The TextLayout updates lines based on text and attributes changes as necessary. TextChunks inside lines are ranges in the text that have text attributes applied. If a text attribute spans multiple lines there will be at least as many chunks as lines, each referring to the text attribute.

If line wrapping is disabled the structure is now:

![image](https://cloud.githubusercontent.com/assets/467450/19018586/c7dbf764-881c-11e6-9e9c-fa9991884853.png)

For each line in the document a WrappedTextLayoutLine is created. This object can split it's line content (text + text attributes) based on the `wrapAt` value of the layouter. It will create as many TextLayoutLines as necessary to fit the given space.
## Line breaks

Note that there are differences in how line endings are handled by normal line breaks and wrapped line breaks:

Given a line `abc`. It has a starting position of `{row: 0, column: 0}` and end position `{row: 0, column: 3}`. The text cursor can be placed at `{row: 0, column: 3}` and will be rendered after the c.

If the line is wrapped after "b" and the cursor is placed at `{row: 0, column: 2}` it will be rendered at the beginning of the subsequent line. The model behind that is that there is a newline character at the end of every natural line and you can place the cursor between it and the last normal character. Wrapped lines have no newline character so there is nothing to place the cursor between. 
## document and screen position

Wrapped text creates a new "coordinate system" inside the text. Normally positions and ranges in text are identified by `{row, column}` pairs that map directly to a text morph's document and document lines.

Wrapped text creates the need to differentiate "screen positions" from those "document positions". Screen positions are also expressed in `{row,column}` form but refer to what is visible in terms of wrapped content.

Given a line `abc` and it being wrapped after b: Screen positions `{row: 0, column: 2}` and `{row: 1, column: 0}` both map to document position `{row: 0, column: 2}`. So in a sense, screen positions contain more information than document positions as those do not contain the information about wrapped line breaks.

The TextLayout object provides an interface for working with pos kinds of positions:

```
pixelPositionFor(morph, {row, column})          => {x, y}
pixelPositionForScreenPos(morph, {row, column}) => {x, y}
boundsFor(morph, {row, column})                 => {x,y,width,height}
boundsForScreenPos(morph, {row, column})        => {x,y,width,height}
screenPositionFor(morph, {x, y})                => {row, column}
docToScreenPos(morph, {row, column})            => {row, column}
screenToDocPos(morph, {row, column})            => {row, column}
```

Note that most of the time for code working with a text morph and its text content it is more convenient to work with document positions (and most of the text commands do that). Only for specific code that e.g. relates position of other morphs to the text it is necessary to use screen positions.
