### PR TITLE
Expt scroll anchor fix for safari and ff

### DIFF
--- a/components/list.js
+++ b/components/list.js
@@ -1,4 +1,4 @@
-import { Morph, GridLayout, Text, StyleSheet, Label, Button, morph } from "lively.morphic";
+import { Morph, config, GridLayout, Text, StyleSheet, Label, Button, morph } from "lively.morphic";
 import { pt, LinearGradient, Color, Rectangle, rect } from "lively.graphics";
 import { arr, Path, string, obj } from "lively.lang";
 import { signal, once } from "lively.bindings";
@@ -254,7 +254,6 @@ var listCommands = [
   }
 ];
 
-
 export class List extends Morph {
 
   static get styleSheet() {
@@ -303,7 +302,7 @@ export class List extends Morph {
         set(value) {
           if (value.eqPt(this.extent)) return;
           this.setProperty("extent", value);
-          this.update();
+          this.renderOnlyVisibleItems && this.update();
         }
       },
 
@@ -428,6 +427,10 @@ export class List extends Morph {
         }
       },
 
+      renderOnlyVisibleItems: {
+        derived: true, readOnly: true,
+        get() { return config.renderOnlyVisibleContent.list; }
+      }
     }
   }
 
@@ -551,8 +554,14 @@ export class List extends Morph {
           padding = padding || Rectangle.inset(0),
           padTop = padding.top(), padLeft = padding.left(),
           padBottom = padding.bottom(), padRight = padding.right(),
-          firstItemIndex = Math.max(0, Math.floor((top + padTop - additionalSpace) / itemHeight)),
-          lastItemIndex = Math.min(items.length, Math.ceil((top + height + padTop + additionalSpace) / itemHeight)),
+          firstItemIndex = this.renderOnlyVisibleItems
+                         ? Math.max(0, Math.floor(
+                             (top + padTop - additionalSpace) / itemHeight))
+                         : 0,
+          lastItemIndex = this.renderOnlyVisibleItems
+                        ? Math.min(items.length, Math.ceil(
+                            (top + height + padTop + additionalSpace) / itemHeight))
+                        : items.length,
           maxWidth = 0,
           goalWidth = this.width - (padLeft + padRight);
 
@@ -609,7 +618,7 @@ export class List extends Morph {
     this.scroll = scroll.addXY(offsetX, offsetY);
   }
 
-  onScroll() { this.update(); }
+  onScroll() { this.renderOnlyVisibleItems && this.update(); }
 
   onItemMorphDoubleClicked(evt, itemMorph) {}
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,8 @@
 /*global System*/
 import { Rectangle, Color } from "lively.graphics";
 
+import bowser from "bowser"
+
 if (typeof $world !== "undefined") {
   $world.withAllSubmorphsDo(ea =>
     ea.hasOwnProperty("_cachedKeyhandlers") && (ea._cachedKeyhandlers = null));
@@ -52,6 +54,12 @@ var config = {
   repeatClickInterval: 250, // max time between clicks for double-, triple-click
   longClick: {minDur: 500, maxDur: 1000, maxDist: 2}, // time and distance for long-click
   showTooltipsAfter: .8,
+
+  renderOnlyVisibleContent: {    
+    list: bowser.chrome || bowser.mobile || bowser.tablet,
+    text: bowser.chrome || bowser.mobile || bowser.tablet,
+    tree: bowser.chrome || bowser.mobile || bowser.tablet
+  },
 
   ide: {
     js: {

--- a/morph.js
+++ b/morph.js
@@ -2109,49 +2109,53 @@ export class Morph {
   onScroll(evt) {}
 
   onMouseWheel(evt) {
-return ;
-    var scrollTarget = evt.targetMorphs.find(ea => ea.isClip());
-    if (this !== scrollTarget) return;
-    var {deltaY, deltaX} = evt.domEvt,
-        magnX = Math.abs(deltaX),
-        magnY = Math.abs(deltaY);
 
+    if (false) {
+      // Attempt to fix "over" scrolling, i.e. when scrolled morph reaches the
+      // end, it shouldn't continue to scroll the world
 
-    // This dance here is to avoid "overscroll", i.e. you scroll a clip morph
-    // and it reaches it's boundary. Normally the clip morphs up the scene graph
-    // would now be scrolled, e.g. the world, moving your view away from the morph
-    // you are looking at. This is highly undesirable.
-
-    var kind = "both directions";
-    if (magnX <= 2 && magnY <= 2) kind = "tiny";
-    else if (magnY / magnX <= 0.2) kind = "horizontal";
-    else if (magnX / magnY <= 0.2) kind = "vertical";
-
-
-    if (kind === "tiny") return;
-
-
-    var {x: scrollX, y: scrollY} = this.scroll,
-        newScrollTop = deltaY + scrollY,
-        newScrollLeft = deltaX + scrollX,
-        newScrollBottom = newScrollTop + this.height,
-        newScrollRight = newScrollLeft + this.width,
-        newScrollX, newScrollY;
-
-    if (kind === "vertical" || kind === "both directions") {
-      if (newScrollBottom >= this.scrollExtent.y) newScrollY = this.scrollExtent.y-1;
-      else if (newScrollTop <= 0) newScrollY = 1;
-      if (newScrollY !== undefined) {
-        this.scroll = pt(scrollX, newScrollY);
-        evt.stop();
-      }
-
-    } else if (kind === "horizontal" || kind === "both directions") {
-      if (newScrollRight >= this.scrollExtent.x) newScrollX = this.scrollExtent.x-1;
-      else if (newScrollLeft <= 0) newScrollX = 1;
-      if (newScrollX !== undefined) {
-        this.scroll = pt(newScrollX, scrollY);
-        evt.stop();
+      var scrollTarget = evt.targetMorphs.find(ea => ea.isClip());
+      if (this !== scrollTarget) return;
+      var {deltaY, deltaX} = evt.domEvt,
+          magnX = Math.abs(deltaX),
+          magnY = Math.abs(deltaY);
+      
+      
+      // This dance here is to avoid "overscroll", i.e. you scroll a clip morph
+      // and it reaches it's boundary. Normally the clip morphs up the scene graph
+      // would now be scrolled, e.g. the world, moving your view away from the morph
+      // you are looking at. This is highly undesirable.
+      
+      var kind = "both directions";
+      if (magnX <= 2 && magnY <= 2) kind = "tiny";
+      else if (magnY / magnX <= 0.2) kind = "horizontal";
+      else if (magnX / magnY <= 0.2) kind = "vertical";
+      
+      
+      if (kind === "tiny") return;
+      
+      var {x: scrollX, y: scrollY} = this.scroll,
+          newScrollTop = deltaY + scrollY,
+          newScrollLeft = deltaX + scrollX,
+          newScrollBottom = newScrollTop + this.height,
+          newScrollRight = newScrollLeft + this.width,
+          newScrollX, newScrollY;
+      
+      if (kind === "vertical" || kind === "both directions") {
+        if (newScrollBottom >= this.scrollExtent.y) newScrollY = this.scrollExtent.y-1;
+        else if (newScrollTop <= 0) newScrollY = 1;
+        if (newScrollY !== undefined) {
+          this.scroll = pt(scrollX, newScrollY);
+          evt.stop();
+        }
+        
+      } else if (kind === "horizontal" || kind === "both directions") {
+        if (newScrollRight >= this.scrollExtent.x) newScrollX = this.scrollExtent.x-1;
+        else if (newScrollLeft <= 0) newScrollX = 1;
+        if (newScrollX !== undefined) {
+          this.scroll = pt(newScrollX, scrollY);
+          evt.stop();
+        }
       }
     }
 
@@ -2163,7 +2167,7 @@ return ;
     if (!evt.state.scroll.interactiveScrollInProgress) {
       var {promise: p, resolve} = promise.deferred();
       evt.state.scroll.interactiveScrollInProgress = p;
-      p.debounce = fun.debounce(250, () => {
+      p.debounce = fun.debounce(1000, () => {
         evt.state.scroll.interactiveScrollInProgress = null;
         resolve();
       });


### PR DESCRIPTION
Make exceptions to render full list and text content in Firefox and Safari since those don't support scroll anchoring yet and do icky scrolling otherwise.

Needs also be propagated to tress... TODO.

I leave this as an experimental branch for now since the performance is horrible...